### PR TITLE
Provide `store_batch` function to storage backend in order to save batch of values atomically

### DIFF
--- a/nomos-services/storage/src/backends/mock.rs
+++ b/nomos-services/storage/src/backends/mock.rs
@@ -50,6 +50,13 @@ impl<SerdeOp: StorageSerde + Send + Sync + 'static> StorageBackend for MockStora
         Ok(())
     }
 
+    async fn store_batch(&mut self, keys_values: Vec<(Bytes, Bytes)>) -> Result<(), Self::Error> {
+        for (key, value) in keys_values {
+            let _ = self.inner.insert(key, value);
+        }
+        Ok(())
+    }
+
     async fn load(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
         Ok(self.inner.get(key).cloned())
     }

--- a/nomos-services/storage/src/backends/mod.rs
+++ b/nomos-services/storage/src/backends/mod.rs
@@ -44,6 +44,8 @@ pub trait StorageBackend: Sized {
     type SerdeOperator: StorageSerde + Send + Sync + 'static;
     fn new(config: Self::Settings) -> Result<Self, Self::Error>;
     async fn store(&mut self, key: Bytes, value: Bytes) -> Result<(), Self::Error>;
+    /// Store batch of key/value pairs in one transaction
+    async fn store_batch(&mut self, keys_values: Vec<(Bytes, Bytes)>) -> Result<(), Self::Error>;
     async fn load(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error>;
     /// Loads all values whose keys start with the given prefix.
     async fn load_prefix(&mut self, prefix: &[u8]) -> Result<Vec<Bytes>, Self::Error>;

--- a/nomos-services/utils/src/overwatch/recovery/operators.rs
+++ b/nomos-services/utils/src/overwatch/recovery/operators.rs
@@ -50,7 +50,6 @@ where
         Backend::from_settings(settings)
             .load_state()
             .map(Option::from)
-            .map_err(RecoveryError::from)
     }
 
     fn from_settings(settings: <Self::StateInput as ServiceState>::Settings) -> Self {
@@ -59,10 +58,7 @@ where
     }
 
     async fn run(&mut self, state: Self::StateInput) {
-        let save_result = self
-            .recovery_backend
-            .save_state(&state)
-            .map_err(RecoveryError::from);
+        let save_result = self.recovery_backend.save_state(&state);
         if let Err(error) = save_result {
             error!("{}", error);
         }


### PR DESCRIPTION
## 1. What does this PR implement?

**Provide `store_batch` function to storage backend in order to save batch of values atomically.**

Not sure if this is the right way to go. Just opened for comments.

The reason of creating this change is related to this PR where we should store multiple keys atomically: #1075 

### Justification why this function is needed in addition to existing storage interface.

Current storage interface provides general purpose `execute` function that allows to run arbitrary code within a context of a transaction. In order to call this functions, caller needs to provide backend specific transaction instance. It seems that currently it’s not straightforward to create such Transaction from an OverWatch service. 

Another justification to add this function to storage interface is that this should be a fairly common use case how transactions are used in the system - storing batch of values together.

Alternately could try to refactor current `execute` solution so that it doesn’t require passing backend specific Transaction instance. I started looking into it but this seems to be much larger effort than providing batch function directly.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 5. Link PR to a specific milestone.
