### PR TITLE
fix(DA): Disperse succeeds when data and metadata is the same

### DIFF
--- a/nomos-services/data-availability/dispersal/src/adapters/mempool/mod.rs
+++ b/nomos-services/data-availability/dispersal/src/adapters/mempool/mod.rs
@@ -1,9 +1,27 @@
 pub mod kzgrs;
 
+use std::error::Error;
+
+use nomos_mempool::backend::MempoolError;
 use overwatch::{
     services::{relay::OutboundRelay, ServiceData},
     DynError,
 };
+
+#[derive(Debug)]
+pub enum DaMempoolAdapterError {
+    Mempool(MempoolError),
+    Other(DynError),
+}
+
+impl<E> From<E> for DaMempoolAdapterError
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn from(e: E) -> Self {
+        Self::Other(Box::new(e) as DynError)
+    }
+}
 
 #[async_trait::async_trait]
 pub trait DaMempoolAdapter {
@@ -17,5 +35,5 @@ pub trait DaMempoolAdapter {
         &self,
         blob_id: Self::BlobId,
         metadata: Self::Metadata,
-    ) -> Result<(), DynError>;
+    ) -> Result<(), DaMempoolAdapterError>;
 }

--- a/nomos-services/mempool/src/lib.rs
+++ b/nomos-services/mempool/src/lib.rs
@@ -6,7 +6,7 @@ pub mod verify;
 
 use std::fmt::{Debug, Error, Formatter};
 
-use backend::Status;
+use backend::{MempoolError, Status};
 pub use da::service::{DaMempoolService, DaMempoolSettings};
 use overwatch::services::relay::RelayMessage;
 use tokio::sync::oneshot::Sender;
@@ -16,7 +16,7 @@ pub enum MempoolMsg<BlockId, Payload, Item, Key> {
     Add {
         payload: Payload,
         key: Key,
-        reply_channel: Sender<Result<(), ()>>,
+        reply_channel: Sender<Result<(), MempoolError>>,
     },
     View {
         ancestor_hint: BlockId,

--- a/tests/src/common/da.rs
+++ b/tests/src/common/da.rs
@@ -39,6 +39,7 @@ pub async fn wait_for_indexed_blob(
                 .filter(|(i, _)| i == &from)
                 .flat_map(|(_, blobs)| blobs)
                 .count();
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
     };
 

--- a/tests/src/tests/da/disperse.rs
+++ b/tests/src/tests/da/disperse.rs
@@ -87,6 +87,41 @@ async fn disseminate_retrieve_reconstruct() {
     }
 }
 
+#[tokio::test]
+async fn disseminate_same_data() {
+    const ITERATIONS: usize = 10;
+
+    let topology = Topology::spawn(TopologyConfig::validator_and_executor()).await;
+    let executor = &topology.executors()[0];
+    let num_subnets = executor.config().da_network.backend.num_subnets as usize;
+
+    let data = [1u8; 31];
+
+    let app_id = hex::decode(APP_ID).unwrap();
+    let app_id: [u8; 32] = app_id.clone().try_into().unwrap();
+    let metadata = kzgrs_backend::dispersal::Metadata::new(app_id, Index::from(0));
+
+    let from = 0u64.to_be_bytes();
+    let to = 1u64.to_be_bytes();
+
+    for i in 0..ITERATIONS {
+        println!("iteration {i}");
+        disseminate_with_metadata(executor, &data, metadata).await;
+
+        wait_for_indexed_blob(executor, app_id, from, to, num_subnets).await;
+
+        let executor_blobs = executor.get_indexer_range(app_id, from..to).await;
+        let executor_idx_0_blobs = executor_blobs
+            .iter()
+            .filter(|(i, _)| i == &from)
+            .flat_map(|(_, blobs)| blobs);
+
+        // Index zero shouldn't be empty, validator replicated both blobs to executor
+        // because they both are in the same subnetwork.
+        assert!(executor_idx_0_blobs.count() == 2);
+    }
+}
+
 #[ignore = "for local debugging"]
 #[tokio::test]
 async fn local_testnet() {


### PR DESCRIPTION
## 1. What does this PR implement?

When the same data and metadata are dispersed repeatedly - dispersal succeeds, but response from the executor mempool is `Err(ExistingItem)`. Before, this error was considered as failure by Dispersal service, now it is considered as success.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@bacv, @danielSanchezQ 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
