### PR TITLE
feat(blend): separate unhealthy conn tolerance from malicious tolerance

### DIFF
--- a/nomos-blend/network/src/lib.rs
+++ b/nomos-blend/network/src/lib.rs
@@ -131,9 +131,11 @@ mod test {
         let conn_monitor_settings = ConnectionMonitorSettings {
             interval: Duration::from_secs(1),
             expected_effective_messages: U57F7::from_num(0.0),
-            effective_message_tolerance: U57F7::from_num(0.0),
+            effective_message_malicious_tolerance: U57F7::from_num(0.0),
+            effective_message_unhealthy_tolerance: U57F7::from_num(0.0),
             expected_drop_messages: U57F7::from_num(0.0),
-            drop_message_tolerance: U57F7::from_num(0.0),
+            drop_message_malicious_tolerance: U57F7::from_num(0.0),
+            drop_message_unhealthy_tolerance: U57F7::from_num(0.0),
         };
         let (mut nodes, mut keypairs) = nodes(2, 8290);
         let node1_addr = nodes.next().unwrap().address;
@@ -203,9 +205,11 @@ mod test {
         let conn_monitor_settings = ConnectionMonitorSettings {
             interval: Duration::from_secs(1),
             expected_effective_messages: U57F7::from_num(1.0),
-            effective_message_tolerance: U57F7::from_num(0.0),
+            effective_message_malicious_tolerance: U57F7::from_num(0.0),
+            effective_message_unhealthy_tolerance: U57F7::from_num(0.0),
             expected_drop_messages: U57F7::from_num(0.0),
-            drop_message_tolerance: U57F7::from_num(0.0),
+            drop_message_malicious_tolerance: U57F7::from_num(0.0),
+            drop_message_unhealthy_tolerance: U57F7::from_num(0.0),
         };
         let (mut nodes, mut keypairs) = nodes(2, 8390);
         let node1_addr = nodes.next().unwrap().address;


### PR DESCRIPTION
## 1. What does this PR implement?

Closes https://github.com/logos-co/nomos/issues/944.

Instead of having a single parameter `effective_message_tolerance`, now we have two separate parameters: `effective_message_malicious_tolerance` and `effective_message_unhealthy_tolerance`. Each tolerance is intended for use in detecting malicious connections and unhealthy connections, respectively, as defined in the [spec](https://www.notion.so/Nomos-Blend-Network-Tier-1-Persistent-Transmission-Module-10b8f96fb65c807cb1e8f92a7f41a771?pvs=4#11c8f96fb65c806db454e80add388ab7). Please see the issue for more details.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
