### PR TITLE
fix: Return mempool error when AddItem fails

### DIFF
--- a/nomos-services/mempool/src/da/service.rs
+++ b/nomos-services/mempool/src/da/service.rs
@@ -348,6 +348,10 @@ where
     NetworkAdapter::Settings: Clone + Send + 'static,
     RecoveryBackend: RecoveryBackendTrait,
 {
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "Mempool message handling is convenient to have in one block"
+    )]
     fn handle_mempool_message(
         &mut self,
         message: MempoolMsg<Pool::BlockId, NetworkAdapter::Payload, Pool::Item, Pool::Key>,
@@ -377,11 +381,14 @@ where
                             adapter.send(item).await;
                         });
                         if let Err(e) = reply_channel.send(Ok(())) {
-                            tracing::debug!("Failed to send reply to AddTx: {:?}", e);
+                            tracing::debug!("Failed to send reply to AddTx: {e:?}");
                         }
                     }
                     Err(e) => {
-                        tracing::debug!("could not add tx to the pool due to: {}", e);
+                        tracing::debug!("could not add tx to the pool due to: {e}");
+                        if let Err(e) = reply_channel.send(Err(e)) {
+                            tracing::debug!("Failed to send reply to AddTx: {e:?}");
+                        }
                     }
                 }
             }

--- a/nomos-services/mempool/src/tx/service.rs
+++ b/nomos-services/mempool/src/tx/service.rs
@@ -181,6 +181,10 @@ where
     NetworkAdapter::Settings: Clone + Send + 'static,
     RecoveryBackend: RecoveryBackendTrait,
 {
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "Mempool message handling is convenient to have in one block"
+    )]
     fn handle_mempool_message(
         &mut self,
         message: MempoolMsg<Pool::BlockId, Pool::Item, Pool::Item, Pool::Key>,
@@ -210,11 +214,14 @@ where
                             adapter.send(item).await;
                         });
                         if let Err(e) = reply_channel.send(Ok(())) {
-                            tracing::debug!("Failed to send reply to AddTx: {:?}", e);
+                            tracing::debug!("Failed to send reply to AddTx: {e:?}");
                         }
                     }
                     Err(e) => {
-                        tracing::debug!("could not add tx to the pool due to: {}", e);
+                        tracing::debug!("could not add tx to the pool due to: {e}");
+                        if let Err(e) = reply_channel.send(Err(e)) {
+                            tracing::debug!("Failed to send reply to AddTx: {e:?}");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 1. What does this PR implement?

In mempool [refactor] one line was missed which returns MempoolError through reply channel.
In this PR I also added the same error reporting to tx mempool. Because of a new line added to the message handling code - clippy complaints about cognitive complexity - we can either allow it or extract function as done in DA.

Please share you preference and I'll update other pool to match the decision.

## 2. Does the code have enough context to be clearly understood?

A line was missed in a refactor https://github.com/logos-co/nomos/pull/1133/files#diff-d5ae27d19a7f2625f3277f74b24650e441ea8b9ac1e0de0f3fe2cadd15cef25bL395

## 3. Who are the specification authors and who is accountable for this PR?

|@bacv @ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
