### PR TITLE
fix(DA): Sampling behaviour lost requests

### DIFF
--- a/nomos-da/network/core/src/protocols/sampling/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/behaviour.rs
@@ -541,7 +541,7 @@ impl<Membership: MembershipHandler<Id = PeerId, NetworkId = SubnetworkId> + 'sta
         let control = control.clone();
         let sample_request = sampling::SampleRequest::new(blob_id, subnetwork_id);
         let with_dial_task: SamplingStreamFuture = async move {
-            // If we don't have an existing connection to the peer, this will immediatly
+            // If we don't have an existing connection to the peer, this will immediately
             // return `ConnectionReset` io error. To handle that, we need to queue
             // `sample_request` for a peer and try again when the connection is
             // established.

--- a/nomos-da/network/core/src/protocols/sampling/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/behaviour.rs
@@ -387,7 +387,7 @@ where
             }
         };
 
-        // Safety: blob_id should always be a 32bytes hash
+        // `blob_id` should always be a 32bytes hash
         Ok((peer_id, SampleStreamResponse::Writer(response), stream))
     }
 
@@ -694,7 +694,7 @@ impl<Membership: MembershipHandler<Id = PeerId, NetworkId = SubnetworkId> + 'sta
                     ));
                 }
                 Err((error, maybe_stream)) => {
-                    Self::handle_stream_error(to_sample, to_close, error, maybe_stream);
+                    return Self::handle_stream_error(to_sample, to_close, error, maybe_stream);
                 }
             }
         }

--- a/nomos-da/network/core/src/swarm/common/monitor.rs
+++ b/nomos-da/network/core/src/swarm/common/monitor.rs
@@ -287,7 +287,7 @@ where
                     stats.last_sampling_failure = Some(now);
                 }
                 MonitorEvent::Noop => {}
-            };
+            }
 
             Some(ConnectionMonitorOutput {
                 peer_id: *peer_id,

--- a/nomos-da/network/core/src/swarm/common/monitor.rs
+++ b/nomos-da/network/core/src/swarm/common/monitor.rs
@@ -375,7 +375,8 @@ mod tests {
         for _ in 0..4 {
             monitor.record_event(MonitorEvent::Sampling(SamplingError::Io {
                 peer_id,
-                error: std::io::Error::new(std::io::ErrorKind::Other, "Simulated I/O error"),
+                error: std::io::Error::other("Simulated I/O error"),
+                message: None,
             }));
         }
 
@@ -393,7 +394,8 @@ mod tests {
         for _ in 0..100 {
             monitor.record_event(MonitorEvent::Sampling(SamplingError::Io {
                 peer_id,
-                error: std::io::Error::new(std::io::ErrorKind::Other, "Simulated I/O error"),
+                error: std::io::Error::other("Simulated I/O error"),
+                message: None,
             }));
         }
 
@@ -411,7 +413,8 @@ mod tests {
         for _ in 0..4 {
             monitor.record_event(MonitorEvent::Sampling(SamplingError::Io {
                 peer_id,
-                error: std::io::Error::new(std::io::ErrorKind::Other, "Simulated I/O error"),
+                error: std::io::Error::other("Simulated I/O error"),
+                message: None,
             }));
         }
 
@@ -434,7 +437,8 @@ mod tests {
         for _ in 0..4 {
             monitor.record_event(MonitorEvent::Sampling(SamplingError::Io {
                 peer_id,
-                error: std::io::Error::new(std::io::ErrorKind::Other, "Simulated I/O error"),
+                error: std::io::Error::other("Simulated I/O error"),
+                message: None,
             }));
         }
 

--- a/nomos-da/network/messages/src/sampling.rs
+++ b/nomos-da/network/messages/src/sampling.rs
@@ -36,7 +36,7 @@ impl SampleError {
 }
 
 #[repr(C)]
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SampleRequest {
     pub blob_id: BlobId,
     pub share_idx: ShareIndex,

--- a/tests/src/topology/configs/da.rs
+++ b/tests/src/topology/configs/da.rs
@@ -60,10 +60,10 @@ impl Default for DaParams {
             policy_settings: DAConnectionPolicySettings {
                 min_dispersal_peers: 1,
                 min_replication_peers: 1,
-                max_dispersal_failures: 1,
-                max_sampling_failures: 1,
-                max_replication_failures: 1,
-                malicious_threshold: 2,
+                max_dispersal_failures: 0,
+                max_sampling_failures: 0,
+                max_replication_failures: 0,
+                malicious_threshold: 0,
             },
             monitor_settings: DAConnectionMonitorSettings {
                 failure_time_window: Duration::from_secs(5),

--- a/tests/src/topology/configs/da.rs
+++ b/tests/src/topology/configs/da.rs
@@ -60,10 +60,10 @@ impl Default for DaParams {
             policy_settings: DAConnectionPolicySettings {
                 min_dispersal_peers: 1,
                 min_replication_peers: 1,
-                max_dispersal_failures: 2,
-                max_sampling_failures: 2,
-                max_replication_failures: 2,
-                malicious_threshold: 10,
+                max_dispersal_failures: 1,
+                max_sampling_failures: 1,
+                max_replication_failures: 1,
+                malicious_threshold: 2,
             },
             monitor_settings: DAConnectionMonitorSettings {
                 failure_time_window: Duration::from_secs(5),

--- a/tests/src/topology/mod.rs
+++ b/tests/src/topology/mod.rs
@@ -57,10 +57,10 @@ impl TopologyConfig {
                 policy_settings: DAConnectionPolicySettings {
                     min_dispersal_peers: 1,
                     min_replication_peers: 1,
-                    max_dispersal_failures: 2,
-                    max_sampling_failures: 2,
-                    max_replication_failures: 2,
-                    malicious_threshold: 10,
+                    max_dispersal_failures: 0,
+                    max_sampling_failures: 0,
+                    max_replication_failures: 0,
+                    malicious_threshold: 0,
                 },
                 balancer_interval: Duration::from_secs(5),
                 ..Default::default()
@@ -83,10 +83,10 @@ impl TopologyConfig {
                 policy_settings: DAConnectionPolicySettings {
                     min_dispersal_peers: 1,
                     min_replication_peers: dispersal_factor - 1,
-                    max_dispersal_failures: 2,
-                    max_sampling_failures: 2,
-                    max_replication_failures: 2,
-                    malicious_threshold: 10,
+                    max_dispersal_failures: 0,
+                    max_sampling_failures: 0,
+                    max_replication_failures: 0,
+                    malicious_threshold: 0,
                 },
                 balancer_interval: Duration::from_secs(5),
                 ..Default::default()


### PR DESCRIPTION
## 1. What does this PR implement?

It was observed that even in the perfect network conditions some sampling requests wouldn't be sent. There were couple of cases that were not handled as sampling behavior doesn't necessary start the stream between peers:
- When there is no connection between peers `open_stream` returns `ConnectionReset` io error, sample request fails.
- When a stream is being reused, receiving end already has stopped listening to the stream after the first message - sample request fails.
- UnexpectedEof happens when peer closes the stream and in our case this is expected and shouldn't be propagated as an error.

Since dispersal service now has an option to try sampling before publishing into the mempool, a small change was made in sampling service to ensure that sampling service invalidates only blobs that it was requested to sample.

One other change might not be very obvious, but receiving end now tries to listen to the incoming stream as long as it gets the close Eof signal from remote peer. Outgoing and Incoming tasks are put into the same tasks queue.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@bacv

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
