### PR TITLE
ci: Use locked dependency versions for cargo binstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 RUN apt-get update && apt-get install -yq \
     git gcc g++ clang libssl-dev pkg-config ca-certificates
 
-RUN cargo install cargo-binstall
+RUN cargo install cargo-binstall --locked
 
 # Versions of cargo-risczero > 1.2.0 use rzup install instead
 RUN cargo binstall cargo-risczero@1.2.0 --no-confirm

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -23,6 +23,6 @@ RUN mkdir -p /home/jenkins/.local/share/cargo-risczero/toolchains \
 
 USER jenkins
 
-RUN cargo install cargo-binstall
+RUN cargo install cargo-binstall --locked
 RUN cargo binstall -y cargo-risczero
 RUN cargo risczero install

--- a/testnet/Dockerfile
+++ b/testnet/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN apt-get update && apt-get install -yq \
     git gcc g++ clang libssl-dev pkg-config ca-certificates
 
-RUN cargo install cargo-binstall
+RUN cargo install cargo-binstall --locked
 RUN cargo binstall cargo-risczero@1.2.0 --no-confirm
 RUN cargo risczero install
 


### PR DESCRIPTION
## 1. What does this PR implement?

This PR updates the installation command for `cargo-binstall` to use `--locked`.
Without `--locked`, Cargo may attempt to resolve newer dependency versions, leading to build failures due to breaking changes in transitive dependencies. Specifically, `h3-quinn v0.0.7` fails to compile due to private field access in quinn::StreamId, causing cargo install cargo-binstall to break.

This does not affect the github action.

## 2. Does the code have enough context to be clearly understood?

Example of failing build when the `cargo-binstall` is not locked.
https://github.com/logos-co/nomos/actions/runs/13925045508/job/38967212800

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
