### PR TITLE
chore: Update nomos image to match repository name

### DIFF
--- a/compose.static.yml
+++ b/compose.static.yml
@@ -4,7 +4,7 @@ services:
 
   cfgsync:
     container_name: cfgsync
-    image: ghcr.io/logos-co/nomos-node:testnet
+    image: ghcr.io/logos-co/nomos:testnet
     volumes:
       - ./testnet:/etc/nomos
     depends_on:
@@ -13,7 +13,7 @@ services:
 
   nomos-node-0:
     container_name: nomos_node_0
-    image: ghcr.io/logos-co/nomos-node:testnet
+    image: ghcr.io/logos-co/nomos:testnet
     ports:
       - "3000:3000/udp"
       - "18080:18080/tcp"
@@ -26,7 +26,7 @@ services:
 
   nomos-node-1:
     container_name: nomos_node_1
-    image: ghcr.io/logos-co/nomos-node:testnet
+    image: ghcr.io/logos-co/nomos:testnet
     volumes:
       - ./testnet:/etc/nomos
       - ./tests/kzgrs/kzgrs_test_params:/kzgrs_test_params:z
@@ -39,7 +39,7 @@ services:
 
   nomos-node-2:
     container_name: nomos_node_2
-    image: ghcr.io/logos-co/nomos-node:testnet
+    image: ghcr.io/logos-co/nomos:testnet
     volumes:
       - ./testnet:/etc/nomos
       - ./tests/kzgrs/kzgrs_test_params:/kzgrs_test_params:z
@@ -52,7 +52,7 @@ services:
 
   nomos-node-3:
     container_name: nomos_node_3
-    image: ghcr.io/logos-co/nomos-node:testnet
+    image: ghcr.io/logos-co/nomos:testnet
     volumes:
       - ./testnet:/etc/nomos
       - ./tests/kzgrs/kzgrs_test_params:/kzgrs_test_params:z


### PR DESCRIPTION
## 1. What does this PR implement?

Nomos testnet runs `compose.static.yaml` which uses image published to the ghrc.io (https://github.com/logos-co/nomos/pkgs/container/nomos). Update to the repository name also changed the image name.

## 2. Does the code have enough context to be clearly understood?

N/A

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
