### PR TITLE
feature: Add bounded duration compatibility for core::time::Duration

### DIFF
--- a/nomos-utils/src/bounded_duration.rs
+++ b/nomos-utils/src/bounded_duration.rs
@@ -1,6 +1,8 @@
 use std::{fmt::Display, marker::PhantomData};
 
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::Error as DeError, ser::Error as SerError, Deserialize, Deserializer, Serialize, Serializer,
+};
 use serde_with::{DeserializeAs, SerializeAs};
 use time::Duration;
 
@@ -95,6 +97,40 @@ impl<'de, const MIN_DURATION: usize, TAG: TimeTag> DeserializeAs<'de, Duration>
     }
 }
 
+impl<const MIN_DURATION: usize, TAG: TimeTag> SerializeAs<core::time::Duration>
+    for MinimalBoundedDuration<MIN_DURATION, TAG>
+{
+    fn serialize_as<S>(source: &core::time::Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let to_serialize: Self = Self {
+            duration: Duration::new(
+                source.as_secs().try_into().map_err(S::Error::custom)?,
+                source.subsec_nanos().try_into().map_err(S::Error::custom)?,
+            ),
+            _tag: PhantomData,
+        };
+        to_serialize.serialize(serializer)
+    }
+}
+impl<'de, const MIN_DURATION: usize, TAG: TimeTag> DeserializeAs<'de, core::time::Duration>
+    for MinimalBoundedDuration<MIN_DURATION, TAG>
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<core::time::Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let duration: Self = Self::deserialize(deserializer)?;
+        if duration.duration.is_negative() {
+            return Err(D::Error::custom(
+                "Negative duration is not supported for std::time::Duration",
+            ));
+        }
+        duration.try_into().map_err(D::Error::custom)
+    }
+}
+
 impl<'de, const MIN_DURATION: usize, TAG: TimeTag> Deserialize<'de>
     for MinimalBoundedDuration<MIN_DURATION, TAG>
 {
@@ -103,22 +139,23 @@ impl<'de, const MIN_DURATION: usize, TAG: TimeTag> Deserialize<'de>
         D: Deserializer<'de>,
     {
         let value: Duration = Duration::deserialize(deserializer)?;
-        let reformat_measure = fill_duration_measure::<TAG>().map_err(Error::custom)?;
+
+        let reformat_measure = fill_duration_measure::<TAG>().map_err(D::Error::custom)?;
         let parsed_duration =
             humantime::parse_duration(format!("{MIN_DURATION}{reformat_measure}").as_str())
-                .map_err(Error::custom)?;
+                .map_err(D::Error::custom)?;
         let min_duration: Duration = Duration::new(
             parsed_duration
                 .as_secs()
                 .try_into()
-                .map_err(Error::custom)?,
+                .map_err(D::Error::custom)?,
             parsed_duration
                 .subsec_nanos()
                 .try_into()
-                .map_err(Error::custom)?,
+                .map_err(D::Error::custom)?,
         );
         if value < min_duration {
-            return Err(Error::custom(format!(
+            return Err(D::Error::custom(format!(
                 "Minimal duration is {min_duration} but got {value}"
             )));
         }
@@ -134,6 +171,26 @@ impl<const MIN_DURATION: usize, TAG: TimeTag> From<MinimalBoundedDuration<MIN_DU
 {
     fn from(value: MinimalBoundedDuration<MIN_DURATION, TAG>) -> Self {
         value.duration
+    }
+}
+
+impl<const MIN_DURATION: usize, TAG: TimeTag> TryFrom<MinimalBoundedDuration<MIN_DURATION, TAG>>
+    for core::time::Duration
+{
+    type Error = std::io::Error;
+
+    fn try_from(value: MinimalBoundedDuration<MIN_DURATION, TAG>) -> Result<Self, Self::Error> {
+        let secs = value
+            .duration
+            .whole_seconds()
+            .try_into()
+            .map_err(Self::Error::other)?;
+        let nanos = value
+            .duration
+            .subsec_nanoseconds()
+            .try_into()
+            .map_err(Self::Error::other)?;
+        Ok(Self::new(secs, nanos))
     }
 }
 
@@ -173,6 +230,21 @@ mod test {
             duration: Duration::seconds(10),
         };
         let _foo: Foo = serde_json::from_value(serde_json::to_value(&foo).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn deserialize_proxy_type_success_for_std() {
+        #[serde_as]
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Foo {
+            #[serde_as(as = "MinimalBoundedDuration<1, SECOND>")]
+            duration: std::time::Duration,
+        }
+        let foo = Foo {
+            duration: std::time::Duration::from_secs(10),
+        };
+        let value = serde_json::to_value(&foo).unwrap();
+        let _foo: Foo = serde_json::from_value(value).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## 1. What does this PR implement?

Added bounded duration compatibility with `core::time::Duration`. Notice that when using `MinimalBoundedTime` duration serialization defaults to human readable (basically delegates into `time::Duration` serialization). This change may make some current config fail. But on the other hand, it would be easier to handle them. cc: @bacv.

## 2. Does the code have enough context to be clearly understood?

Just added trait implementation so we can deserialize into `core::time::Duration`.

## 3. Who are the specification authors and who is accountable for this PR?
N/A
## 4. Is the specification accurate and complete?
N/A
## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
