### PR TITLE
fix: Use bytemuck_derive 1.8.1 for risc0

### DIFF
--- a/nomos-core/risc0_proofs/bundle_balance/Cargo.toml
+++ b/nomos-core/risc0_proofs/bundle_balance/Cargo.toml
@@ -12,5 +12,7 @@ nomos_proof_statements = { path = "../../proof_statements" }
 risc0-zkvm             = { version = "1.2.0", default-features = false, features = ['std'] }
 
 [patch.crates-io]
+# TODO: remove when risc0 suppors rust 1.85; bytemuck_derive version 1.8.1
+bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck.git", rev = "45fbae7d8ddb8d75353588920c6fab16943e96bd" }
 # add RISC Zero accelerator support for all downstream usages of the following crates.
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }

--- a/nomos-core/risc0_proofs/covenant_nop/Cargo.toml
+++ b/nomos-core/risc0_proofs/covenant_nop/Cargo.toml
@@ -9,3 +9,7 @@ version = "0.1.0"
 [dependencies]
 nomos_proof_statements = { path = "../../proof_statements" }
 risc0-zkvm             = { version = "1.2.0", default-features = false, features = ['std'] }
+
+[patch.crates-io]
+# TODO: remove when risc0 suppors rust 1.85; bytemuck_derive version 1.8.1
+bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck.git", rev = "45fbae7d8ddb8d75353588920c6fab16943e96bd" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -12,6 +12,8 @@ nomos_proof_statements = { path = "../../proof_statements" }
 risc0-zkvm             = { version = "1.2.0", default-features = false, features = ['std'] }
 
 [patch.crates-io]
+# TODO: remove when risc0 suppors rust 1.85; bytemuck_derive version 1.8.1
+bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck.git", rev = "45fbae7d8ddb8d75353588920c6fab16943e96bd" }
 # add RISC Zero accelerator support for all downstream usages of the following crates.
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 sha2          = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }

--- a/nomos-core/risc0_proofs/ptx/Cargo.toml
+++ b/nomos-core/risc0_proofs/ptx/Cargo.toml
@@ -12,5 +12,7 @@ nomos_proof_statements = { path = "../../proof_statements" }
 risc0-zkvm             = { version = "1.2.0", default-features = false, features = ['std'] }
 
 [patch.crates-io]
+# TODO: remove when risc0 suppors rust 1.85; bytemuck_derive version 1.8.1
+bytemuck_derive = { git = "https://github.com/Lokathor/bytemuck.git", rev = "45fbae7d8ddb8d75353588920c6fab16943e96bd" }
 # add RISC Zero accelerator support for all downstream usages of the following crates.
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }


### PR DESCRIPTION
## 1. What does this PR implement?

`bytemuck_derive` is risc0 dependency and after a new release it became inccompatible with 1.81.0 rustc toolchain that risc0 uses.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.

