### PR TITLE
fix(DA): Pass share verification domain size from the configuration in verifier

### DIFF
--- a/nomos-services/data-availability/verifier/src/backend/kzgrs.rs
+++ b/nomos-services/data-availability/verifier/src/backend/kzgrs.rs
@@ -26,6 +26,7 @@ impl std::error::Error for KzgrsDaVerifierError {}
 
 pub struct KzgrsDaVerifier {
     verifier: NomosKzgrsVerifier,
+    domain_size: usize,
 }
 
 impl VerifierBackend for KzgrsDaVerifier {
@@ -36,7 +37,10 @@ impl VerifierBackend for KzgrsDaVerifier {
             .expect("Global parameters has to be loaded from file");
 
         let verifier = NomosKzgrsVerifier::new(global_params);
-        Self { verifier }
+        Self {
+            verifier,
+            domain_size: settings.domain_size,
+        }
     }
 }
 
@@ -51,9 +55,8 @@ impl DaVerifier for KzgrsDaVerifier {
     ) -> Result<(), Self::Error> {
         // TODO: Prepare the domain depending the size, if fixed, so fixed domain, if
         // not it needs to come with some metadata.
-        let domain_size = 2usize;
         self.verifier
-            .verify(commitments, light_share, domain_size)
+            .verify(commitments, light_share, self.domain_size)
             .then_some(())
             .ok_or(KzgrsDaVerifierError::VerificationError)
     }
@@ -62,4 +65,5 @@ impl DaVerifier for KzgrsDaVerifier {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KzgrsDaVerifierSettings {
     pub global_params_path: String,
+    pub domain_size: usize,
 }

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -296,6 +296,7 @@ pub fn create_executor_config(config: GeneralConfig) -> Config {
         da_verifier: DaVerifierServiceSettings {
             verifier_settings: KzgrsDaVerifierSettings {
                 global_params_path: config.da_config.global_params_path.clone(),
+                domain_size: config.da_config.num_subnets as usize,
             },
             network_adapter_settings: (),
             storage_adapter_settings: VerifierStorageAdapterSettings {

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -347,6 +347,7 @@ pub fn create_validator_config(config: GeneralConfig) -> Config {
         da_verifier: DaVerifierServiceSettings {
             verifier_settings: KzgrsDaVerifierSettings {
                 global_params_path: config.da_config.global_params_path,
+                domain_size: config.da_config.num_subnets as usize,
             },
             network_adapter_settings: (),
             storage_adapter_settings: VerifierStorageAdapterSettings {

--- a/tests/src/tests/da/disperse.rs
+++ b/tests/src/tests/da/disperse.rs
@@ -52,7 +52,7 @@ async fn disseminate_and_retrieve() {
 async fn disseminate_retrieve_reconstruct() {
     const ITERATIONS: usize = 10;
 
-    let topology = Topology::spawn(TopologyConfig::validator_and_executor()).await;
+    let topology = Topology::spawn(TopologyConfig::validators_and_executor(3, 4, 2)).await;
     let executor = &topology.executors()[0];
     let num_subnets = executor.config().da_network.backend.num_subnets as usize;
 
@@ -134,7 +134,7 @@ async fn disseminate_same_data() {
 #[ignore = "for local debugging"]
 #[tokio::test]
 async fn local_testnet() {
-    let topology = Topology::spawn(TopologyConfig::validators_and_executor(3, 2)).await;
+    let topology = Topology::spawn(TopologyConfig::validators_and_executor(3, 2, 2)).await;
     let executor = &topology.executors()[0];
     let app_id = hex::decode(APP_ID).expect("Invalid APP_ID");
 

--- a/tests/src/tests/da/disperse.rs
+++ b/tests/src/tests/da/disperse.rs
@@ -1,8 +1,11 @@
 use std::time::Duration;
 
 use kzgrs_backend::{dispersal::Index, reconstruction::reconstruct_without_missing_data};
+use nomos_core::da::blob::Share;
+use subnetworks_assignations::MembershipHandler;
 use tests::{
     common::da::{disseminate_with_metadata, wait_for_indexed_blob, APP_ID},
+    secret_key_to_peer_id,
     topology::{Topology, TopologyConfig},
 };
 
@@ -52,7 +55,7 @@ async fn disseminate_and_retrieve() {
 async fn disseminate_retrieve_reconstruct() {
     const ITERATIONS: usize = 10;
 
-    let topology = Topology::spawn(TopologyConfig::validators_and_executor(3, 4, 2)).await;
+    let topology = Topology::spawn(TopologyConfig::validator_and_executor()).await;
     let executor = &topology.executors()[0];
     let num_subnets = executor.config().da_network.backend.num_subnets as usize;
 
@@ -94,6 +97,98 @@ async fn disseminate_retrieve_reconstruct() {
     assert!(executor.monitor_stats().await.0.is_empty());
     assert_eq!(validator.balancer_stats().await.len(), 2);
     assert!(validator.monitor_stats().await.0.is_empty());
+}
+
+#[ignore = "Reenable when tools to inspect mempool are added"]
+#[tokio::test]
+async fn four_subnets_disseminate_retrieve_reconstruct() {
+    const ITERATIONS: usize = 10;
+
+    let topology = Topology::spawn(TopologyConfig::validators_and_executor(3, 4, 2)).await;
+    let membership = &topology.validators()[0]
+        .config()
+        .da_network
+        .backend
+        .membership;
+
+    let validator_subnet_0 = topology
+        .validators()
+        .iter()
+        .find(|v| {
+            let node_key = v.config().da_network.backend.node_key.clone();
+            let peer_id = secret_key_to_peer_id(node_key);
+            let subnets = membership.membership(&peer_id);
+            subnets.contains(&0)
+        })
+        .expect("Validator subnet 0 not found");
+
+    let validator_subnet_1 = topology
+        .validators()
+        .iter()
+        .find(|v| {
+            let node_key = v.config().da_network.backend.node_key.clone();
+            let peer_id = secret_key_to_peer_id(node_key);
+            let subnets = membership.membership(&peer_id);
+            subnets.contains(&1)
+        })
+        .expect("Validator subnet 1 not found");
+
+    let executor = &topology.executors()[0];
+
+    let app_id = hex::decode(APP_ID).unwrap();
+    let app_id: [u8; 32] = app_id.clone().try_into().unwrap();
+
+    let data = [1u8; 31 * ITERATIONS];
+
+    for i in 0..ITERATIONS {
+        let data_size = 31 * (i + 1);
+        println!("disseminating {data_size} bytes");
+        let data = &data[..data_size]; // test increasing size data
+        let metadata = kzgrs_backend::dispersal::Metadata::new(app_id, Index::from(i as u64));
+        disseminate_with_metadata(executor, data, metadata).await;
+
+        let from = i.to_be_bytes();
+        let to = (i + 1).to_be_bytes();
+
+        // Executor is participating only in two subnetworks out of 4. We are waiting
+        // here for shares availability in executor for both of those
+        // subnetworks, thats why we are passing `2` instead of `num_subnets`.
+        wait_for_indexed_blob(executor, app_id, from, to, 2).await;
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        let validator_subnet_0_idx_0 = validator_subnet_0.get_indexer_range(app_id, from..to).await;
+        let validator_idx_0_blobs: Vec<_> = validator_subnet_0_idx_0
+            .iter()
+            .filter(|(i, _)| i == &from)
+            .flat_map(|(_, blobs)| blobs)
+            .filter(|share| share.share_idx() == [0, 0])
+            .collect();
+
+        let validator_subnet_1_idx_0 = validator_subnet_1.get_indexer_range(app_id, from..to).await;
+        let validator_1_blobs: Vec<_> = validator_subnet_1_idx_0
+            .iter()
+            .filter(|(i, _)| i == &from)
+            .flat_map(|(_, blobs)| blobs)
+            .filter(|share| share.share_idx() == [0, 1])
+            .collect();
+
+        let reconstruction_shares = vec![
+            validator_idx_0_blobs[0].clone(),
+            validator_1_blobs[0].clone(),
+        ];
+
+        // Reconstruction is performed from the one of the two blobs.
+        let reconstructed = reconstruct_without_missing_data(&reconstruction_shares);
+        assert_eq!(&reconstructed[..data.len()], data);
+    }
+
+    // TODO think about a test with malicious/unhealthy peers that'd trigger
+    // recording some monitor stats too
+    assert_eq!(executor.balancer_stats().await.len(), 2);
+    assert!(executor.monitor_stats().await.0.is_empty());
+    assert_eq!(validator_subnet_0.balancer_stats().await.len(), 2);
+    assert!(validator_subnet_0.monitor_stats().await.0.is_empty());
 }
 
 #[tokio::test]

--- a/tests/src/topology/mod.rs
+++ b/tests/src/topology/mod.rs
@@ -84,7 +84,7 @@ impl TopologyConfig {
                 subnetwork_size: num_subnets,
                 num_subnets: num_subnets as u16,
                 policy_settings: DAConnectionPolicySettings {
-                    min_dispersal_peers: num_subnets - 1,
+                    min_dispersal_peers: num_subnets,
                     min_replication_peers: dispersal_factor - 1,
                     max_dispersal_failures: 0,
                     max_sampling_failures: 0,

--- a/tests/src/topology/mod.rs
+++ b/tests/src/topology/mod.rs
@@ -1,6 +1,6 @@
 pub mod configs;
 
-use std::{ops::Add, time::Duration};
+use std::time::Duration;
 
 use configs::{
     da::{create_da_configs, DaParams},
@@ -70,8 +70,11 @@ impl TopologyConfig {
     }
 
     #[must_use]
-    pub fn validators_and_executor(num_validators: usize, num_subnets: usize) -> Self {
-        let dispersal_factor = num_validators.add(1).saturating_div(num_subnets);
+    pub fn validators_and_executor(
+        num_validators: usize,
+        num_subnets: usize,
+        dispersal_factor: usize,
+    ) -> Self {
         Self {
             n_validators: num_validators,
             n_executors: 1,
@@ -81,7 +84,7 @@ impl TopologyConfig {
                 subnetwork_size: num_subnets,
                 num_subnets: num_subnets as u16,
                 policy_settings: DAConnectionPolicySettings {
-                    min_dispersal_peers: 1,
+                    min_dispersal_peers: num_subnets - 1,
                     min_replication_peers: dispersal_factor - 1,
                     max_dispersal_failures: 0,
                     max_sampling_failures: 0,


### PR DESCRIPTION
## 1. What does this PR implement?

When dispersing data to a network with more than two subnets, the share wouldn't be included in the block because verification would fail because of fixed domain size in verifier. To fix this, size is now passed from the configuration, test was added but ignored, because it seems that in a network of 4 nodes a longer time is needed to wait until all nodes mark the blob in block. This will be fixed in the future when in integration tests we'll be able to use mempool inspection tools to know when tests can proceed with assertions.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @bacv 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
