### PR TITLE
SyncPeerMessage type for sync networking

### DIFF
--- a/consensus/cryptarchia-sync/network/src/behaviour.rs
+++ b/consensus/cryptarchia-sync/network/src/behaviour.rs
@@ -100,6 +100,8 @@ pub enum SyncError {
     ChannelSendError(#[from] mpsc::error::SendError<BehaviourSyncReply>),
     #[error("IO error: {0}")]
     IOError(#[from] std::io::Error),
+    #[error("Invalid message: {0}")]
+    InvalidMessage(String),
 }
 
 pub struct SyncBehaviour<Membership> {

--- a/consensus/cryptarchia-sync/network/src/lib.rs
+++ b/consensus/cryptarchia-sync/network/src/lib.rs
@@ -3,3 +3,4 @@ pub mod membership;
 mod sync_incoming;
 mod sync_outgoing;
 mod sync_utils;
+mod messages;

--- a/consensus/cryptarchia-sync/network/src/messages.rs
+++ b/consensus/cryptarchia-sync/network/src/messages.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SyncPeerMessage {
+    Block(Vec<u8>),
+    TipData(u64),
+    End,
+}

--- a/consensus/cryptarchia-sync/network/src/sync_incoming.rs
+++ b/consensus/cryptarchia-sync/network/src/sync_incoming.rs
@@ -3,6 +3,7 @@ use libp2p::Stream;
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::messages::SyncPeerMessage;
 use crate::{
     behaviour::{BehaviourSyncReply, IncomingSyncRequest, RequestKind, SyncError, SyncRequest},
     sync_utils,
@@ -37,16 +38,23 @@ pub fn send_response_to_peer(
 
         while let Some(service_response) = response_receiver.next().await {
             match service_response {
-                BehaviourSyncReply::TipData(tip) => {
-                    sync_utils::send_data(&mut req.stream, &tip).await?;
-                }
                 BehaviourSyncReply::Block(block) => {
-                    sync_utils::send_data(&mut req.stream, &block).await?;
+                    let message = SyncPeerMessage::Block(block);
+                    sync_utils::send_data(&mut req.stream, &message).await?;
+                }
+                BehaviourSyncReply::TipData(tip) => {
+                    let message = SyncPeerMessage::TipData(tip);
+                    sync_utils::send_data(&mut req.stream, &message).await?;
                 }
             }
             req.stream.flush().await?;
         }
+
+        sync_utils::send_data(&mut req.stream, &SyncPeerMessage::End).await?;
+
+        req.stream.flush().await?;
         req.stream.close().await?;
+
         Ok(())
     })
 }

--- a/consensus/cryptarchia-sync/network/src/sync_outgoing.rs
+++ b/consensus/cryptarchia-sync/network/src/sync_outgoing.rs
@@ -10,6 +10,7 @@ use tokio::{
 };
 use tracing::{error, info};
 
+use crate::messages::SyncPeerMessage;
 use crate::{
     behaviour::{SyncDirection, SyncError, SyncRequest, SYNC_PROTOCOL},
     membership::ConsensusMembershipHandler,
@@ -80,9 +81,22 @@ pub async fn stream_blocks_from_peer(
     let mut stream = sync_utils::open_stream(peer_id, control, SYNC_PROTOCOL).await?;
     sync_utils::send_data(&mut stream, &SyncRequest::Sync { direction }).await?;
 
-    while let Ok(block) = sync_utils::receive_data(&mut stream).await {
-        if response_sender.send(block).is_err() {
-            break;
+    loop {
+        let message: SyncPeerMessage = sync_utils::receive_data(&mut stream).await?;
+        match message {
+            SyncPeerMessage::Block(block) => {
+                if response_sender.send(block).is_err() {
+                    break;
+                }
+            }
+            SyncPeerMessage::End => {
+                info!(peer_id = %peer_id, "Received end signal");
+                break;
+            }
+            SyncPeerMessage::TipData(_) => {
+                error!("Unexpected message during sync: {:?}", message);
+                break;
+            }
         }
     }
     stream.close().await?;
@@ -90,18 +104,30 @@ pub async fn stream_blocks_from_peer(
     info!(peer_id = %peer_id, "Finished streaming blocks");
     Ok(())
 }
-
 async fn request_tip_from_peer(peer_id: PeerId, mut control: Control) -> Result<u64, SyncError> {
     let mut stream = sync_utils::open_stream(peer_id, &mut control, SYNC_PROTOCOL).await?;
     sync_utils::send_data(&mut stream, &SyncRequest::RequestTip).await?;
 
-    let tip = sync_utils::receive_data(&mut stream).await?;
+    let message: SyncPeerMessage = sync_utils::receive_data(&mut stream).await?;
+    let SyncPeerMessage::TipData(tip) = message else {
+        return Err(SyncError::InvalidMessage(
+            "Expected TipData message".to_owned(),
+        ));
+    };
+
+    let end_message: SyncPeerMessage = sync_utils::receive_data(&mut stream).await?;
+    if matches!(end_message, SyncPeerMessage::End) {
+    } else {
+        return Err(SyncError::InvalidMessage(
+            "Expected End message after TipData".to_owned(),
+        ));
+    }
+
     stream.close().await?;
 
     info!(peer_id = %peer_id, tip = tip, "Received tip");
     Ok(tip)
 }
-
 pub fn sync_after_requesting_tips<Membership>(
     control: Control,
     membership: Membership,


### PR DESCRIPTION
NOTE: This is a PoC to be merged to the feat/cryptarchia-sync branch. So, this doesn't follow the PR description template. This PoC will be substantially refactored in the future before opening PRs for the master.


Added explicit message for sync networking.