### PR TITLE
Use single location to count sync requests

### DIFF
--- a/consensus/cryptarchia-sync/network/src/sync_incoming.rs
+++ b/consensus/cryptarchia-sync/network/src/sync_incoming.rs
@@ -2,7 +2,7 @@ use futures::{future::BoxFuture, AsyncWriteExt, StreamExt};
 use libp2p::Stream;
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
-
+use tracing::info;
 use crate::{
     behaviour::{BehaviourSyncReply, IncomingSyncRequest, RequestKind, SyncError, SyncRequest},
     sync_utils,
@@ -42,6 +42,10 @@ pub fn send_response_to_peer(
                 }
                 BehaviourSyncReply::Block(block) => {
                     sync_utils::send_data(&mut req.stream, &block).await?;
+                }
+                BehaviourSyncReply::Failed(e) => {
+                    info!("Service reported sync failure: {e:?}");
+
                 }
             }
             req.stream.flush().await?;

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -1058,7 +1058,7 @@ where
                     });
             }
             _ => {
-                sync_data_provider.process_sync_request(request);
+                sync_data_provider.process_sync_request(request).await;
             }
         }
     }

--- a/tests/src/tests/cryptarchia/sync/cryptarchia.rs
+++ b/tests/src/tests/cryptarchia/sync/cryptarchia.rs
@@ -240,7 +240,7 @@ where
                                         .expect("Failed to send tip response");
                                 }
                                 _ => {
-                                    sync_data_provider.process_sync_request(sync_request);
+                                    sync_data_provider.process_sync_request(sync_request).await;
                                 }
                             }
                         },


### PR DESCRIPTION
NOTE: This is a PoC to be merged to the feat/cryptarchia-sync branch. So, this doesn't follow the PR description template. This PoC will be substantially refactored in the future before opening PRs for the master.

Removed sync requests counter from Behaviour.