### PR TITLE
chore: update tauri builder version to match the CI 

### DIFF
--- a/nomos-bundler/Cargo.toml
+++ b/nomos-bundler/Cargo.toml
@@ -9,7 +9,7 @@ clap          = { version = "4.5.27", features = ["derive"] }
 env_logger    = "0.11.6"
 log           = "0.4.22"
 serde_json    = "1.0.135"
-tauri-bundler = "2.2.1"
+tauri-bundler = "2.4.0"
 tauri-utils   = "2.1.1"
 
 [[bin]]

--- a/nomos-bundler/nomos-node/bundle.rs
+++ b/nomos-bundler/nomos-node/bundle.rs
@@ -7,7 +7,8 @@ use bundler::utils::{
 use clap::{arg, Parser};
 use log::{error, info};
 use tauri_bundler::{
-    AppImageSettings, DebianSettings, DmgSettings, MacOsSettings, RpmSettings, WindowsSettings,
+    AppImageSettings, DebianSettings, DmgSettings, IosSettings, MacOsSettings, RpmSettings,
+    WindowsSettings,
 };
 use tauri_utils::platform::target_triple;
 
@@ -94,6 +95,7 @@ fn build_package(version: String) {
             macos: MacOsSettings::default(),
             updater: None,
             windows: WindowsSettings::default(),
+            ios: IosSettings::default(),
         })
         .binaries(vec![tauri_bundler::BundleBinary::new(
             String::from(CRATE_NAME),


### PR DESCRIPTION
The compile breaks on the CI because the tauri builder version is automatically updates. The make the code compile and work both locally and on CI, one of the possible solution was to update the version




