### PR TITLE
feat(api): return blob id in disperse call

### DIFF
--- a/nodes/nomos-executor/executor/src/api/backend.rs
+++ b/nodes/nomos-executor/executor/src/api/backend.rs
@@ -252,6 +252,7 @@ where
         > + Send
         + Sync
         + 'static,
+    DispersalBackend::BlobId: Serialize,
     DispersalBackend::Settings: Clone + Send + Sync,
     DispersalNetworkAdapter: nomos_da_dispersal::adapters::network::DispersalNetworkAdapter<
             SubnetworkId = Membership::NetworkId,

--- a/nodes/nomos-executor/executor/src/api/handlers.rs
+++ b/nodes/nomos-executor/executor/src/api/handlers.rs
@@ -12,7 +12,7 @@ use nomos_http_api_common::{paths, types::DispersalRequest};
 use nomos_libp2p::PeerId;
 use nomos_node::make_request_and_return_response;
 use overwatch::{overwatch::handle::OverwatchHandle, services::AsServiceId};
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 use subnetworks_assignations::MembershipHandler;
 
 #[utoipa::path(
@@ -49,6 +49,7 @@ where
         + Sync
         + 'static,
     Backend::Settings: Clone + Send + Sync,
+    Backend::BlobId: Serialize,
     NetworkAdapter: DispersalNetworkAdapter<SubnetworkId = Membership::NetworkId> + Send,
     MempoolAdapter: DaMempoolAdapter,
     Metadata: DeserializeOwned + metadata::Metadata + Debug + Send + 'static,

--- a/nodes/nomos-executor/executor/src/api/handlers.rs
+++ b/nodes/nomos-executor/executor/src/api/handlers.rs
@@ -46,7 +46,8 @@ where
             MempoolAdapter = MempoolAdapter,
             Metadata = Metadata,
         > + Send
-        + Sync,
+        + Sync
+        + 'static,
     Backend::Settings: Clone + Send + Sync,
     NetworkAdapter: DispersalNetworkAdapter<SubnetworkId = Membership::NetworkId> + Send,
     MempoolAdapter: DaMempoolAdapter,

--- a/nodes/nomos-executor/http-client/src/lib.rs
+++ b/nodes/nomos-executor/http-client/src/lib.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, hash::Hash};
 
 pub use common_http_client::{BasicAuthCredentials, CommonHttpClient, Error};
 use futures::Stream;
-use nomos_core::da::blob::Share;
+use nomos_core::da::{blob::Share, BlobId};
 use nomos_http_api_common::{paths, types::DispersalRequest};
 use reqwest::Url;
 use serde::{de::DeserializeOwned, Serialize};
@@ -26,7 +26,7 @@ impl ExecutorHttpClient {
         base_url: Url,
         data: Vec<u8>,
         metadata: Metadata,
-    ) -> Result<(), Error>
+    ) -> Result<BlobId, Error>
     where
         Metadata: Serialize + Send + Sync,
     {
@@ -35,7 +35,7 @@ impl ExecutorHttpClient {
         let request_url = base_url.join(path).map_err(Error::Url)?;
 
         self.client
-            .post::<DispersalRequest<Metadata>, ()>(request_url, &req)
+            .post::<DispersalRequest<Metadata>, BlobId>(request_url, &req)
             .await
     }
 

--- a/nomos-cli/src/cmds/executor.rs
+++ b/nomos-cli/src/cmds/executor.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, sync::mpsc::Sender};
 use clap::Args;
 use executor_http_client::{BasicAuthCredentials, ExecutorHttpClient};
 use kzgrs_backend::{dispersal::Metadata, encoder::DaEncoderParams};
+use nomos_core::da::BlobId;
 use reqwest::Url;
 
 #[derive(Args, Debug)]
@@ -69,7 +70,7 @@ impl Disseminate {
 
         match res_receiver.recv() {
             Ok(update) => match update {
-                Ok(()) => tracing::info!("Data successfully disseminated."),
+                Ok(_) => tracing::info!("Data successfully disseminated."),
                 Err(e) => {
                     tracing::error!("Error disseminating data: {e}");
                     return Err(e.into());
@@ -88,7 +89,7 @@ impl Disseminate {
 
 #[tokio::main]
 async fn disperse_data(
-    res_sender: &Sender<Result<(), String>>,
+    res_sender: &Sender<Result<BlobId, String>>,
     client: &ExecutorHttpClient,
     base_url: Url,
     bytes: Vec<u8>,

--- a/nomos-services/api/src/http/da.rs
+++ b/nomos-services/api/src/http/da.rs
@@ -282,7 +282,7 @@ pub async fn disperse_data<
     handle: &OverwatchHandle<RuntimeServiceId>,
     data: Vec<u8>,
     metadata: Metadata,
-) -> Result<(), DynError>
+) -> Result<Backend::BlobId, DynError>
 where
     Membership: MembershipHandler<NetworkId = SubnetworkId, Id = PeerId>
         + Clone
@@ -295,7 +295,8 @@ where
             MempoolAdapter = MempoolAdapter,
             Metadata = Metadata,
         > + Send
-        + Sync,
+        + Sync
+        + 'static,
     Backend::Settings: Clone + Send + Sync,
     NetworkAdapter: DispersalNetworkAdapter<SubnetworkId = Membership::NetworkId> + Send,
     MempoolAdapter: DaMempoolAdapter,

--- a/nomos-services/api/src/http/da.rs
+++ b/nomos-services/api/src/http/da.rs
@@ -298,6 +298,7 @@ where
         + Sync
         + 'static,
     Backend::Settings: Clone + Send + Sync,
+    Backend::BlobId: Serialize,
     NetworkAdapter: DispersalNetworkAdapter<SubnetworkId = Membership::NetworkId> + Send,
     MempoolAdapter: DaMempoolAdapter,
     Metadata: metadata::Metadata + Debug + Send + 'static,

--- a/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
+++ b/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
@@ -208,7 +208,7 @@ where
         &self,
         data: Vec<u8>,
         metadata: Self::Metadata,
-    ) -> Result<(), DynError> {
+    ) -> Result<Self::BlobId, DynError> {
         let (blob_id, encoded_data) = self.encode(data).await?;
         info_with_id!(blob_id.as_ref(), "ProcessDispersal");
         self.disperse(encoded_data).await?;
@@ -253,6 +253,6 @@ where
                 }
             }
         }
-        Ok(())
+        Ok(blob_id)
     }
 }

--- a/nomos-services/data-availability/dispersal/src/backend/mod.rs
+++ b/nomos-services/data-availability/dispersal/src/backend/mod.rs
@@ -3,7 +3,6 @@ use std::{fmt::Debug, time::Duration};
 use nomos_core::da::{blob::metadata, DaDispersal, DaEncoder};
 use nomos_tracing::info_with_id;
 use overwatch::DynError;
-use serde::Serialize;
 use tracing::instrument;
 
 use crate::adapters::{mempool::DaMempoolAdapter, network::DispersalNetworkAdapter};
@@ -18,7 +17,7 @@ pub trait DispersalBackend {
     type NetworkAdapter: DispersalNetworkAdapter;
     type MempoolAdapter: DaMempoolAdapter;
     type Metadata: Debug + metadata::Metadata + Send;
-    type BlobId: AsRef<[u8]> + Send + Copy + Serialize;
+    type BlobId: AsRef<[u8]> + Send + Copy;
 
     fn init(
         config: Self::Settings,

--- a/nomos-services/data-availability/dispersal/src/backend/mod.rs
+++ b/nomos-services/data-availability/dispersal/src/backend/mod.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, time::Duration};
 
-use nomos_core::da::{blob::metadata, BlobId, DaDispersal, DaEncoder};
+use nomos_core::da::{blob::metadata, DaDispersal, DaEncoder};
 use nomos_tracing::info_with_id;
 use overwatch::DynError;
 use serde::Serialize;

--- a/nomos-services/data-availability/dispersal/src/lib.rs
+++ b/nomos-services/data-availability/dispersal/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     marker::PhantomData,
 };
 
-use nomos_core::da::{blob::metadata, BlobId};
+use nomos_core::da::blob::metadata;
 use nomos_da_network_core::{PeerId, SubnetworkId};
 use overwatch::{
     services::{

--- a/nomos-services/data-availability/dispersal/src/lib.rs
+++ b/nomos-services/data-availability/dispersal/src/lib.rs
@@ -54,6 +54,7 @@ pub struct DispersalService<
         + Sync
         + 'static,
     Backend: DispersalBackend<NetworkAdapter = NetworkAdapter, Metadata = Metadata>,
+    Backend::BlobId: Serialize,
     Backend::Settings: Clone,
     NetworkAdapter: DispersalNetworkAdapter,
     MempoolAdapter: DaMempoolAdapter,
@@ -80,6 +81,7 @@ where
         + Sync
         + 'static,
     Backend: DispersalBackend<NetworkAdapter = NetworkAdapter, Metadata = Metadata>,
+    Backend::BlobId: Serialize,
     Backend::Settings: Clone,
     NetworkAdapter: DispersalNetworkAdapter,
     MempoolAdapter: DaMempoolAdapter,
@@ -116,6 +118,7 @@ where
         > + Send
         + Sync,
     Backend::Settings: Clone + Send + Sync,
+    Backend::BlobId: Serialize,
     NetworkAdapter: DispersalNetworkAdapter<SubnetworkId = Membership::NetworkId> + Send,
     <NetworkAdapter::NetworkService as ServiceData>::Message: 'static,
     MempoolAdapter: DaMempoolAdapter,


### PR DESCRIPTION
## 1. What does this PR implement?
The disperse call for the da is not returning blob id. This information is useful to track blob ids when interacting with da.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?
Yes
## 5. Does the implementation introduce changes in the specification?

There is a change in da dispersal api return object to include blob id.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
