### PR TITLE
refactor(sdp): Activity message

### DIFF
--- a/nomos-sdp/src/ledger.rs
+++ b/nomos-sdp/src/ledger.rs
@@ -156,10 +156,13 @@ impl<Declarations, Activity, Services, Stakes, Proof, Metadata, ContractAddress>
     SdpLedger<Declarations, Activity, Services, Stakes, Proof, Metadata, ContractAddress>
 where
     Declarations: DeclarationsRepository + Send + Sync,
-    Activity: ActivityContract<Metadata = Metadata, ContractAddress = ContractAddress> + Send,
-    Services: ServicesRepository<ContractAddress = ContractAddress> + Send,
+    Activity:
+        ActivityContract<Metadata = Metadata, ContractAddress = ContractAddress> + Send + Sync,
+    Services: ServicesRepository<ContractAddress = ContractAddress> + Send + Sync,
     Stakes: StakesVerifier<Proof = Proof> + Send + Sync,
-    ContractAddress: Debug,
+    ContractAddress: Debug + Send + Sync,
+    Proof: Send + Sync,
+    Metadata: Send + Sync,
 {
     pub fn new(
         declaration_repo: Declarations,

--- a/nomos-sdp/src/ledger.rs
+++ b/nomos-sdp/src/ledger.rs
@@ -8,8 +8,8 @@ use std::{
 use async_trait::async_trait;
 
 use crate::{
-    BlockNumber, Declaration, DeclarationId, DeclarationMessage, DeclarationUpdate, EventType,
-    Nonce, ProviderId, ProviderInfo, RewardId, RewardMessage, SdpMessage, ServiceParameters,
+    ActiveMessage, ActivityId, BlockNumber, Declaration, DeclarationId, DeclarationMessage,
+    DeclarationUpdate, EventType, Nonce, ProviderId, ProviderInfo, SdpMessage, ServiceParameters,
     ServiceType, WithdrawMessage,
     state::{ProviderState, ProviderStateError},
 };
@@ -70,23 +70,23 @@ pub trait ServicesRepository {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum RewardsSenderError<ContractAddress> {
-    #[error("Reward contract not found: {0:?}")]
+pub enum ActivityContractError<ContractAddress> {
+    #[error("Activity contract not found: {0:?}")]
     NotFound(ContractAddress),
     #[error(transparent)]
     Other(Box<dyn Error + Send + Sync>),
 }
 
 #[async_trait]
-pub trait RewardsRequestSender {
+pub trait ActivityContract {
     type ContractAddress: Debug;
     type Metadata;
 
-    async fn request_reward(
+    async fn mark_active(
         &self,
-        reward_contract: Self::ContractAddress,
-        reward_message: RewardMessage<Self::Metadata>,
-    ) -> Result<(), RewardsSenderError<Self::ContractAddress>>;
+        contract_address: Self::ContractAddress,
+        active_message: ActiveMessage<Self::Metadata>,
+    ) -> Result<(), ActivityContractError<Self::ContractAddress>>;
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -119,7 +119,7 @@ pub enum SdpLedgerError<ContractAddress: Debug> {
     #[error(transparent)]
     DeclarationsRepository(#[from] DeclarationsRepositoryError),
     #[error(transparent)]
-    RewardsSender(#[from] RewardsSenderError<ContractAddress>),
+    ActivityContract(#[from] ActivityContractError<ContractAddress>),
     #[error(transparent)]
     ServicesRepository(#[from] ServicesRepositoryError),
     #[error(transparent)]
@@ -136,45 +136,45 @@ pub enum SdpLedgerError<ContractAddress: Debug> {
     Other(Box<dyn Error + Send + Sync>),
 }
 
-pub struct SdpLedger<Declarations, Rewards, Services, Stakes, Proof, Metadata, ContractAddress>
+pub struct SdpLedger<Declarations, Activity, Services, Stakes, Proof, Metadata, ContractAddress>
 where
     Declarations: DeclarationsRepository,
-    Rewards: RewardsRequestSender,
+    Activity: ActivityContract,
     Services: ServicesRepository,
 {
     declaration_repo: Declarations,
-    reward_request_sender: Rewards,
+    activity_contract: Activity,
     services_repo: Services,
     stake_verifier: Stakes,
     pending_providers: HashMap<BlockNumber, HashMap<ProviderId, ProviderInfo>>,
     pending_declarations: HashMap<BlockNumber, HashMap<ProviderId, DeclarationUpdate>>,
-    pending_rewards: HashMap<ProviderId, RewardId>,
+    pending_activity: HashMap<ProviderId, ActivityId>,
     _phantom: PhantomData<(Proof, Metadata, ContractAddress)>,
 }
 
-impl<Declarations, Rewards, Services, Stakes, Proof, Metadata, ContractAddress>
-    SdpLedger<Declarations, Rewards, Services, Stakes, Proof, Metadata, ContractAddress>
+impl<Declarations, Activity, Services, Stakes, Proof, Metadata, ContractAddress>
+    SdpLedger<Declarations, Activity, Services, Stakes, Proof, Metadata, ContractAddress>
 where
     Declarations: DeclarationsRepository + Send + Sync,
-    Rewards: RewardsRequestSender<Metadata = Metadata, ContractAddress = ContractAddress> + Send,
+    Activity: ActivityContract<Metadata = Metadata, ContractAddress = ContractAddress> + Send,
     Services: ServicesRepository<ContractAddress = ContractAddress> + Send,
     Stakes: StakesVerifier<Proof = Proof> + Send + Sync,
     ContractAddress: Debug,
 {
     pub fn new(
         declaration_repo: Declarations,
-        reward_request_sender: Rewards,
+        activity_contract: Activity,
         services_repo: Services,
         stake_verifier: Stakes,
     ) -> Self {
         Self {
             declaration_repo,
-            reward_request_sender,
+            activity_contract,
             services_repo,
             stake_verifier,
             pending_providers: HashMap::new(),
             pending_declarations: HashMap::new(),
-            pending_rewards: HashMap::new(),
+            pending_activity: HashMap::new(),
             _phantom: PhantomData,
         }
     }
@@ -228,25 +228,25 @@ where
         Ok(pending_state)
     }
 
-    async fn process_reward(
+    async fn process_active(
         &mut self,
         block_number: BlockNumber,
         current_state: ProviderState,
-        reward_message: RewardMessage<Metadata>,
+        active_message: ActiveMessage<Metadata>,
         service_params: ServiceParameters<ContractAddress>,
     ) -> Result<ProviderState, SdpLedgerError<ContractAddress>> {
-        // Check if state can transition before requesting a reward.
-        let pending_state = current_state.try_into_active(block_number, EventType::Reward)?;
-        let provider_id = reward_message.provider_id;
-        let declaration_id = reward_message.declaration_id;
-        let service_type = reward_message.service_type;
+        // Check if state can transition before marking as active.
+        let pending_state = current_state.try_into_active(block_number, EventType::Activity)?;
+        let provider_id = active_message.provider_id;
+        let declaration_id = active_message.declaration_id;
+        let service_type = active_message.service_type;
 
         self.declaration_repo
-            .check_nonce(provider_id, reward_message.nonce)
+            .check_nonce(provider_id, active_message.nonce)
             .await?;
 
         // One declaration can be for multiple services, and each service could have
-        // different provider id, allow reward only for the service that
+        // different provider id, allow marking active only for the service that
         // provider is providing.
         if let Ok(declaration) = self.declaration_repo.get_declaration(declaration_id).await {
             if !declaration.has_service_provider(service_type, provider_id) {
@@ -254,28 +254,28 @@ where
             }
         }
 
-        // Reward can be sent, but state never transition, we need to allow state
-        // transition if `provider_info` got rewarded, but didn't transition state for
-        // some reason.
-        if let Entry::Vacant(entry) = self.pending_rewards.entry(provider_id) {
-            let reward_id = reward_message.reward_id();
-            self.reward_request_sender
-                .request_reward(service_params.reward_contract, reward_message)
+        // Activity can be recorded, but state never transition, we need to allow state
+        // transition if `provider_info` got marked active, but didn't transition state
+        // for some reason.
+        if let Entry::Vacant(entry) = self.pending_activity.entry(provider_id) {
+            let activity_id = active_message.activity_id();
+            self.activity_contract
+                .mark_active(service_params.activity_contract, active_message)
                 .await?;
-            entry.insert(reward_id);
+            entry.insert(activity_id);
         }
 
         Ok(pending_state)
     }
 
     async fn process_withdraw(
-        &mut self,
+        &self,
         block_number: BlockNumber,
         current_state: ProviderState,
-        withdraw_message: WithdrawMessage<Metadata>,
+        withdraw_message: WithdrawMessage,
         service_params: ServiceParameters<ContractAddress>,
     ) -> Result<ProviderState, SdpLedgerError<ContractAddress>> {
-        let mut pending_state = current_state.try_into_withdrawn(
+        let pending_state = current_state.try_into_withdrawn(
             block_number,
             EventType::Withdrawal,
             &service_params,
@@ -294,27 +294,6 @@ where
         if let Ok(declaration) = self.declaration_repo.get_declaration(declaration_id).await {
             if !declaration.has_service_provider(service_type, provider_id) {
                 return Err(SdpLedgerError::ServiceNotProvided(service_type));
-            }
-        }
-
-        // Block can contain reward and rewardable withdraw message, only process one
-        // reward for provider service per block.
-        if let Entry::Vacant(entry) = self.pending_rewards.entry(provider_id) {
-            if let Ok(reward_message) = RewardMessage::try_from(withdraw_message) {
-                let reward_id = reward_message.reward_id();
-
-                // If withdrawal to withdrawal with reward state transition fails, reward can't
-                // be sent.
-                pending_state = pending_state.try_into_withdrawn(
-                    block_number,
-                    EventType::Reward,
-                    &service_params,
-                )?;
-
-                self.reward_request_sender
-                    .request_reward(service_params.reward_contract, reward_message)
-                    .await?;
-                entry.insert(reward_id);
             }
         }
 
@@ -364,8 +343,8 @@ where
                 self.process_declare(block_number, current_state, declaration_message)
                     .await?
             }
-            SdpMessage::Reward(reward_message) => {
-                self.process_reward(block_number, current_state, reward_message, service_params)
+            SdpMessage::Activity(active_message) => {
+                self.process_active(block_number, current_state, active_message, service_params)
                     .await?
             }
             SdpMessage::Withdraw(withdraw_message) => {
@@ -434,8 +413,9 @@ where
 
         for info in updates.values() {
             let id = info.provider_id;
-            // Rewards are expected to be marked in block by entity that manages rewards.
-            self.pending_rewards.remove(&id);
+            // Activity contract is expected to be marked in block by entity that manages
+            // activity.
+            self.pending_activity.remove(&id);
 
             if let Err(err) = self.mark_declaration_in_block(block_number, info).await {
                 tracing::error!("Provider information couldn't be updated: {err}");
@@ -449,7 +429,7 @@ where
         self.pending_declarations.remove(&block_number);
         if let Some(updates) = self.pending_providers.remove(&block_number) {
             for ProviderInfo { provider_id, .. } in updates.values() {
-                self.pending_rewards.remove(provider_id);
+                self.pending_activity.remove(provider_id);
             }
         }
     }
@@ -474,7 +454,7 @@ mod tests {
     type MockProof = [u8; 32];
     type MockSdpLedger = SdpLedger<
         MockDeclarationsRepository,
-        MockRewardsRequestSender,
+        MockActivityContract,
         MockServicesRepository,
         MockStakesVerifier,
         MockProof,
@@ -506,7 +486,7 @@ mod tests {
             ));
         }
 
-        pub fn add_reward(
+        pub fn add_activity(
             &mut self,
             provider_id: ProviderId,
             declaration_id: DeclarationId,
@@ -514,7 +494,7 @@ mod tests {
             should_pass: bool,
         ) {
             self.messages.push((
-                SdpMessage::Reward(RewardMessage {
+                SdpMessage::Activity(ActiveMessage {
                     declaration_id,
                     service_type,
                     provider_id,
@@ -530,7 +510,6 @@ mod tests {
             provider_id: ProviderId,
             declaration_id: DeclarationId,
             service_type: ServiceType,
-            with_meta: bool,
             should_pass: bool,
         ) {
             self.messages.push((
@@ -539,7 +518,6 @@ mod tests {
                     service_type,
                     provider_id,
                     nonce: [0u8; 16],
-                    metadata: with_meta.then_some([0u8; 32]),
                 }),
                 should_pass,
             ));
@@ -558,7 +536,7 @@ mod tests {
     enum BOp {
         Dec(ProviderId, ServiceType, Vec<Locator>),
         Rew(ProviderId, DeclarationId, ServiceType),
-        Wit(ProviderId, DeclarationId, ServiceType, bool),
+        Wit(ProviderId, DeclarationId, ServiceType),
     }
 
     // Short alias for better formatting.
@@ -575,10 +553,10 @@ mod tests {
                             block.add_declaration(pid, service, locators, should_pass);
                         }
                         BOp::Rew(pid, did, service) => {
-                            block.add_reward(pid, did, service, should_pass);
+                            block.add_activity(pid, did, service, should_pass);
                         }
-                        BOp::Wit(pid, did, service, with_reward) => {
-                            block.add_withdraw(pid, did, service, with_reward, should_pass);
+                        BOp::Wit(pid, did, service) => {
+                            block.add_withdraw(pid, did, service, should_pass);
                         }
                     }
                 }
@@ -680,21 +658,21 @@ mod tests {
     }
 
     #[derive(Default, Clone)]
-    struct MockRewardsRequestSender {
-        requested_rewards: Arc<Mutex<Vec<RewardMessage<MockContractAddress>>>>,
+    struct MockActivityContract {
+        activity_records: Arc<Mutex<Vec<ActiveMessage<MockContractAddress>>>>,
     }
 
     #[async_trait]
-    impl RewardsRequestSender for MockRewardsRequestSender {
+    impl ActivityContract for MockActivityContract {
         type ContractAddress = MockContractAddress;
         type Metadata = MockMetadata;
 
-        async fn request_reward(
+        async fn mark_active(
             &self,
-            _reward_contract: Self::ContractAddress,
-            reward_message: RewardMessage<Self::ContractAddress>,
-        ) -> Result<(), RewardsSenderError<Self::ContractAddress>> {
-            self.requested_rewards.lock().unwrap().push(reward_message);
+            _activity_contract: Self::ContractAddress,
+            activity_message: ActiveMessage<Self::ContractAddress>,
+        ) -> Result<(), ActivityContractError<Self::ContractAddress>> {
+            self.activity_records.lock().unwrap().push(activity_message);
             Ok(())
         }
     }
@@ -741,7 +719,7 @@ mod tests {
             lock_period: 10,
             inactivity_period: 20,
             retention_period: 30,
-            reward_contract: [0u8; 32],
+            activity_contract: [0u8; 32],
             timestamp: 0,
         }
     }
@@ -749,11 +727,11 @@ mod tests {
     fn setup_ledger() -> (
         MockSdpLedger,
         MockDeclarationsRepository,
-        MockRewardsRequestSender,
+        MockActivityContract,
         MockServicesRepository,
     ) {
         let declaration_repo = MockDeclarationsRepository::default();
-        let rewards_sender = MockRewardsRequestSender::default();
+        let activity_contract = MockActivityContract::default();
         let service_repo = MockServicesRepository::default();
         let stake_verifier = MockStakesVerifier;
 
@@ -765,16 +743,16 @@ mod tests {
 
         let ledger = SdpLedger {
             declaration_repo: declaration_repo.clone(),
-            reward_request_sender: rewards_sender.clone(),
+            activity_contract: activity_contract.clone(),
             services_repo: service_repo.clone(),
             stake_verifier,
             pending_providers: HashMap::new(),
             pending_declarations: HashMap::new(),
-            pending_rewards: HashMap::new(),
+            pending_activity: HashMap::new(),
             _phantom: PhantomData,
         };
 
-        (ledger, declaration_repo, rewards_sender, service_repo)
+        (ledger, declaration_repo, activity_contract, service_repo)
     }
 
     #[tokio::test]
@@ -803,12 +781,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_reward_message() {
-        let (mut ledger, _, rewards_sender, _) = setup_ledger();
+    async fn test_process_activity_message() {
+        let (mut ledger, _, activity_contract, _) = setup_ledger();
         let provider_id = ProviderId([0u8; 32]);
         let declaration_id = DeclarationId([1u8; 32]);
 
-        let reward_message = RewardMessage {
+        let active_message = ActiveMessage {
             declaration_id,
             service_type: ServiceType::BlendNetwork,
             provider_id,
@@ -817,7 +795,7 @@ mod tests {
         };
 
         let result = ledger
-            .process_sdp_message(100, SdpMessage::Reward(reward_message.clone()))
+            .process_sdp_message(100, SdpMessage::Activity(active_message.clone()))
             .await;
 
         assert!(result.is_ok());
@@ -825,15 +803,15 @@ mod tests {
         assert_eq!(ledger.pending_providers.len(), 1);
         assert!(ledger.pending_providers.contains_key(&100));
 
-        let requested_rewards = rewards_sender.requested_rewards.lock().unwrap();
-        assert_eq!(requested_rewards.len(), 1);
-        assert_eq!(requested_rewards[0].provider_id, provider_id);
-        drop(requested_rewards); // clippy strict >:)
+        let activity_records = activity_contract.activity_records.lock().unwrap();
+        assert_eq!(activity_records.len(), 1);
+        assert_eq!(activity_records[0].provider_id, provider_id);
+        drop(activity_records); // clippy strict >:)
     }
 
     #[tokio::test]
     async fn test_process_withdraw_message() {
-        let (mut ledger, declaration_repo, rewards_sender, _) = setup_ledger();
+        let (mut ledger, declaration_repo, activity_contract, _) = setup_ledger();
         let provider_id = ProviderId([0u8; 32]);
         let declaration_id = DeclarationId([1u8; 32]);
 
@@ -850,7 +828,6 @@ mod tests {
             service_type: ServiceType::BlendNetwork,
             provider_id,
             nonce: [0; 16],
-            metadata: Some([2u8; 32]),
         };
 
         let result = ledger
@@ -862,10 +839,10 @@ mod tests {
         assert_eq!(ledger.pending_providers.len(), 1);
         assert!(ledger.pending_providers.contains_key(&100));
 
-        let requested_rewards = rewards_sender.requested_rewards.lock().unwrap();
-        assert_eq!(requested_rewards.len(), 1);
-        assert_eq!(requested_rewards[0].provider_id, provider_id);
-        drop(requested_rewards);
+        let activity_records = activity_contract.activity_records.lock().unwrap();
+        assert_eq!(activity_records.len(), 1);
+        assert_eq!(activity_records[0].provider_id, provider_id);
+        drop(activity_records);
     }
 
     #[tokio::test]
@@ -908,16 +885,16 @@ mod tests {
                 ],
             ),
             (10, vec![(BOp::Rew(pid, did, St::BlendNetwork), true)]),
-            // This provider is registered with the BlendNetwork service, should fail to get reward
-            // for DataAvailability service.
+            // This provider is registered with the BlendNetwork service, should fail to records
+            // activity for DataAvailability service.
             (20, vec![(BOp::Rew(pid, did, St::DataAvailability), false)]),
             (
                 30,
                 vec![
-                    (BOp::Wit(pid, did, St::BlendNetwork, true), true),
+                    (BOp::Wit(pid, did, St::BlendNetwork), true),
                     // Provider only registered the BlendNetwork service - withdrawal for DA should
                     // fail.
-                    (BOp::Wit(pid, did, St::DataAvailability, false), false),
+                    (BOp::Wit(pid, did, St::DataAvailability), false),
                 ],
             ),
         ]
@@ -946,7 +923,7 @@ mod tests {
                 provider_id: pid,
                 declaration_id: did,
                 created: 0,
-                rewarded: Some(30),
+                active: Some(30),
                 withdrawn: Some(30)
             }
         );
@@ -990,9 +967,9 @@ mod tests {
                 30,
                 vec![
                     // Withdrawing service that pid2 declared.
-                    (BOp::Wit(pid1, did, St::BlendNetwork, true), false),
+                    (BOp::Wit(pid1, did, St::BlendNetwork), false),
                     // Withdrawing service that pid1 declared.
-                    (BOp::Wit(pid2, did, St::DataAvailability, false), false),
+                    (BOp::Wit(pid2, did, St::DataAvailability), false),
                 ],
             ),
         ]
@@ -1020,7 +997,7 @@ mod tests {
                 provider_id: pid1,
                 declaration_id: did,
                 created: 0,
-                rewarded: Some(10),
+                active: Some(10),
                 withdrawn: None, // Last transaction failed.
             }
         );
@@ -1032,7 +1009,7 @@ mod tests {
                 provider_id: pid2,
                 declaration_id: did,
                 created: 0,
-                rewarded: Some(20),
+                active: Some(20),
                 withdrawn: None,
             }
         );

--- a/nomos-sdp/src/ledger.rs
+++ b/nomos-sdp/src/ledger.rs
@@ -535,7 +535,7 @@ mod tests {
     // Block Operation, short for better formatting.
     enum BOp {
         Dec(ProviderId, ServiceType, Vec<Locator>),
-        Rew(ProviderId, DeclarationId, ServiceType),
+        Act(ProviderId, DeclarationId, ServiceType),
         Wit(ProviderId, DeclarationId, ServiceType),
     }
 
@@ -552,7 +552,7 @@ mod tests {
                         BOp::Dec(pid, service, locators) => {
                             block.add_declaration(pid, service, locators, should_pass);
                         }
-                        BOp::Rew(pid, did, service) => {
+                        BOp::Act(pid, did, service) => {
                             block.add_activity(pid, did, service, should_pass);
                         }
                         BOp::Wit(pid, did, service) => {
@@ -839,9 +839,9 @@ mod tests {
         assert_eq!(ledger.pending_providers.len(), 1);
         assert!(ledger.pending_providers.contains_key(&100));
 
+        // Withdrawing doesn't make the provider active.
         let activity_records = activity_contract.activity_records.lock().unwrap();
-        assert_eq!(activity_records.len(), 1);
-        assert_eq!(activity_records[0].provider_id, provider_id);
+        assert_eq!(activity_records.len(), 0);
         drop(activity_records);
     }
 
@@ -884,10 +884,10 @@ mod tests {
                     (BOp::Dec(pid, St::DataAvailability, locators.clone()), false),
                 ],
             ),
-            (10, vec![(BOp::Rew(pid, did, St::BlendNetwork), true)]),
+            (10, vec![(BOp::Act(pid, did, St::BlendNetwork), true)]),
             // This provider is registered with the BlendNetwork service, should fail to records
             // activity for DataAvailability service.
-            (20, vec![(BOp::Rew(pid, did, St::DataAvailability), false)]),
+            (20, vec![(BOp::Act(pid, did, St::DataAvailability), false)]),
             (
                 30,
                 vec![
@@ -923,7 +923,7 @@ mod tests {
                 provider_id: pid,
                 declaration_id: did,
                 created: 0,
-                active: Some(30),
+                active: Some(10),
                 withdrawn: Some(30)
             }
         );
@@ -961,8 +961,8 @@ mod tests {
                     (BOp::Dec(pid2, St::BlendNetwork, locators.clone()), true),
                 ],
             ),
-            (10, vec![(BOp::Rew(pid1, did, St::DataAvailability), true)]),
-            (20, vec![(BOp::Rew(pid2, did, St::BlendNetwork), true)]),
+            (10, vec![(BOp::Act(pid1, did, St::DataAvailability), true)]),
+            (20, vec![(BOp::Act(pid2, did, St::BlendNetwork), true)]),
             (
                 30,
                 vec![

--- a/nomos-sdp/src/state.rs
+++ b/nomos-sdp/src/state.rs
@@ -31,8 +31,8 @@ impl ActiveState {
                     Err(ActiveStateError::ToActiveNotOnCreated)
                 }
             }
-            EventType::Reward => {
-                self.0.rewarded = Some(block_number);
+            EventType::Activity => {
+                self.0.active = Some(block_number);
                 Ok(self)
             }
             EventType::Withdrawal => Err(ActiveStateError::ToActiveDuringWithdrawal),
@@ -53,7 +53,7 @@ impl ActiveState {
                 self.0.withdrawn = Some(block_number);
                 Ok(WithdrawnState(self.0))
             }
-            EventType::Declaration | EventType::Reward => {
+            EventType::Declaration | EventType::Activity => {
                 Err(ActiveStateError::ToWithdrawalInvalidEvent(event_type))
             }
         }
@@ -80,8 +80,8 @@ impl InactiveState {
         event_type: EventType,
     ) -> Result<ActiveState, InactiveStateError> {
         match event_type {
-            EventType::Reward => {
-                self.0.rewarded = Some(block_number);
+            EventType::Activity => {
+                self.0.active = Some(block_number);
                 Ok(ActiveState(self.0))
             }
             EventType::Declaration | EventType::Withdrawal => {
@@ -104,7 +104,7 @@ impl InactiveState {
                 self.0.withdrawn = Some(block_number);
                 Ok(WithdrawnState(self.0))
             }
-            EventType::Declaration | EventType::Reward => {
+            EventType::Declaration | EventType::Activity => {
                 Err(InactiveStateError::ToWithdrawalInvalidEvent(event_type))
             }
         }
@@ -113,31 +113,31 @@ impl InactiveState {
 
 #[derive(Error, Debug)]
 pub enum WithdrawnStateError {
-    #[error("Withdawn state can be rewarded only during the same block")]
-    ToWithdrawnRewardedNotSameBlock,
-    #[error("Withdrawn can not transition to withdrawn rewarded during {0:?} event")]
-    ToWithdrawnRewardedInvalidEvent(EventType),
+    #[error("Withdawn state can be active only during the same block")]
+    ToWithdrawnActiveNotSameBlock,
+    #[error("Withdrawn can not transition to withdrawn active during {0:?} event")]
+    ToWithdrawnActiveInvalidEvent(EventType),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct WithdrawnState(ProviderInfo);
 
 impl WithdrawnState {
-    fn try_into_withdrawn_rewarded(
+    fn try_into_withdrawn_active(
         mut self,
         block_number: BlockNumber,
         event_type: EventType,
     ) -> Result<Self, WithdrawnStateError> {
-        if matches!(event_type, EventType::Reward) {
-            // Only allow reward for withdrawal in the same block number.
+        if matches!(event_type, EventType::Activity) {
+            // Only allow activity recorded for withdrawal in the same block number.
             if self.0.withdrawn != Some(block_number) {
-                return Err(WithdrawnStateError::ToWithdrawnRewardedNotSameBlock);
+                return Err(WithdrawnStateError::ToWithdrawnActiveNotSameBlock);
             }
 
-            self.0.rewarded = Some(block_number);
+            self.0.active = Some(block_number);
             Ok(self)
         } else {
-            Err(WithdrawnStateError::ToWithdrawnRewardedInvalidEvent(
+            Err(WithdrawnStateError::ToWithdrawnActiveInvalidEvent(
                 event_type,
             ))
         }
@@ -190,7 +190,7 @@ impl ProviderState {
         }
 
         // This section checks if recently created provider is still considered active
-        // even without having requested a reward yet.
+        // even without having activity recorded yet.
         if provider_info
             .created
             .wrapping_add(service_params.inactivity_period)
@@ -199,10 +199,10 @@ impl ProviderState {
             return Ok(ActiveState(*provider_info).into());
         }
 
-        // Check if provider has ever got the reward first and then see if the reward
-        // request was recent.
-        if let Some(rewarded) = provider_info.rewarded {
-            if block_number.wrapping_sub(rewarded) <= service_params.inactivity_period {
+        // Check if provider has ever got the activity recorded first and then see if
+        // the activity record was recent.
+        if let Some(activity) = provider_info.active {
+            if block_number.wrapping_sub(activity) <= service_params.inactivity_period {
                 return Ok(ActiveState(*provider_info).into());
             }
         }
@@ -220,8 +220,8 @@ impl ProviderState {
         if let Some(withdrawn_timestamp) = provider_info.withdrawn {
             return withdrawn_timestamp;
         }
-        if let Some(rewards_timestamp) = provider_info.rewarded {
-            return rewards_timestamp;
+        if let Some(activity_timestamp) = provider_info.active {
+            return activity_timestamp;
         }
         provider_info.created
     }
@@ -274,11 +274,11 @@ impl ProviderState {
                 .try_into_withdrawn(block_number, event_type, service_params)
                 .map(Into::into)
                 .map_err(ProviderStateError::from),
-            // Withdrawn rewarded state can only transition from withdrawn state and it's only
+            // Withdrawn active state can only transition from withdrawn state and it's only
             // allowed to transition if the withdrawn timestamp matches current block, in other
-            // words, withdrawal can only be rewarded in withdrawal block.
+            // words, withdrawal can only be recorded active in withdrawal block.
             Self::Withdrawn(withdrawn_state) => withdrawn_state
-                .try_into_withdrawn_rewarded(block_number, event_type)
+                .try_into_withdrawn_active(block_number, event_type)
                 .map(Into::into)
                 .map_err(ProviderStateError::from),
         }
@@ -315,7 +315,7 @@ mod tests {
             lock_period: 10,
             inactivity_period: 20,
             retention_period: 100,
-            reward_contract: [0; 32],
+            activity_contract: [0; 32],
             timestamp: 0,
         }
     }
@@ -333,20 +333,20 @@ mod tests {
     }
 
     #[test]
-    fn test_info_to_inactive_rewarded_state() {
+    fn test_info_to_inactive_active_state() {
         let provider_id = ProviderId([0; 32]);
         let declaration_id = DeclarationId([1; 32]);
         let service_params = default_service_params();
         let mut provider_info = ProviderInfo::new(100, provider_id, declaration_id);
-        provider_info.rewarded = Some(110);
+        provider_info.active = Some(110);
 
-        let inactive_rewarded_state =
+        let inactive_activity_record_state =
             ProviderState::try_from_info(200, &provider_info, &service_params).unwrap();
         assert!(matches!(
-            inactive_rewarded_state,
+            inactive_activity_record_state,
             ProviderState::Inactive(_)
         ));
-        assert_eq!(inactive_rewarded_state.last_block_number(), 110);
+        assert_eq!(inactive_activity_record_state.last_block_number(), 110);
     }
 
     #[test]
@@ -362,17 +362,17 @@ mod tests {
     }
 
     #[test]
-    fn test_info_to_active_rewarded_state() {
+    fn test_info_to_active_recorded_state() {
         let provider_id = ProviderId([0; 32]);
         let declaration_id = DeclarationId([1; 32]);
         let service_params = default_service_params();
         let mut provider_info = ProviderInfo::new(100, provider_id, declaration_id);
-        provider_info.rewarded = Some(110);
+        provider_info.active = Some(110);
 
-        let active_rewarded_state =
+        let active_recorded_state =
             ProviderState::try_from_info(111, &provider_info, &service_params).unwrap();
-        assert!(matches!(active_rewarded_state, ProviderState::Active(_)));
-        assert_eq!(active_rewarded_state.last_block_number(), 110);
+        assert!(matches!(active_recorded_state, ProviderState::Active(_)));
+        assert_eq!(active_recorded_state.last_block_number(), 110);
     }
 
     #[test]
@@ -381,7 +381,7 @@ mod tests {
         let declaration_id = DeclarationId([1; 32]);
         let service_params = default_service_params();
         let mut provider_info = ProviderInfo::new(100, provider_id, declaration_id);
-        provider_info.rewarded = Some(111);
+        provider_info.active = Some(111);
         provider_info.withdrawn = Some(121);
 
         let withdrawn_state =
@@ -401,11 +401,13 @@ mod tests {
         let res = ProviderState::try_from_info(2, &provider_info, &service_params);
         assert!(matches!(res, Err(ProviderStateError::BlockFromPast)));
 
-        // Provider rewarded in block 5, trying to withdraw in block 4.
+        // Provider activity recorded in block 5, trying to withdraw in block 4.
         let active_state =
             ProviderState::try_from_info(3, &provider_info, &service_params).unwrap();
-        let rewarded_state = active_state.try_into_active(5, EventType::Reward).unwrap();
-        let res = rewarded_state.try_into_withdrawn(4, EventType::Withdrawal, &service_params);
+        let active_recorded = active_state
+            .try_into_active(5, EventType::Activity)
+            .unwrap();
+        let res = active_recorded.try_into_withdrawn(4, EventType::Withdrawal, &service_params);
         assert!(matches!(res, Err(ProviderStateError::BlockFromPast)));
     }
 
@@ -431,7 +433,7 @@ mod tests {
     }
 
     #[test]
-    fn test_active_to_reward_to_withdraw() {
+    fn test_active_to_activity_recorded_to_withdraw() {
         let provider_id = ProviderId([0; 32]);
         let declaration_id = DeclarationId([1; 32]);
         let service_params = default_service_params();
@@ -439,8 +441,10 @@ mod tests {
 
         let active_state =
             ProviderState::try_from_info(0, &provider_info, &service_params).unwrap();
-        let rewarded_state = active_state.try_into_active(5, EventType::Reward).unwrap();
-        let withdrawn_state = rewarded_state
+        let active_recorded = active_state
+            .try_into_active(5, EventType::Activity)
+            .unwrap();
+        let withdrawn_state = active_recorded
             .try_into_withdrawn(11, EventType::Withdrawal, &service_params)
             .unwrap();
 
@@ -475,16 +479,16 @@ mod tests {
             .try_into_withdrawn(15, EventType::Withdrawal, &service_params)
             .unwrap();
 
-        // Withdrawn state can only be rewarded in the same block.
-        let rewarded_withdrawal = late_withdrawal
-            .try_into_withdrawn(15, EventType::Reward, &service_params)
+        // Withdrawn state can only be activity recorded in the same block.
+        let active_withdrawal = late_withdrawal
+            .try_into_withdrawn(15, EventType::Activity, &service_params)
             .unwrap();
 
-        // Withdrawal can't be rewarded in future.
-        let reward_withdrawal_different_block =
-            rewarded_withdrawal.try_into_withdrawn(16, EventType::Reward, &service_params);
+        // Withdrawal can't be activity recorded in future.
+        let active_withdrawal_different_block =
+            active_withdrawal.try_into_withdrawn(16, EventType::Activity, &service_params);
 
-        assert!(reward_withdrawal_different_block.is_err());
+        assert!(active_withdrawal_different_block.is_err());
     }
 
     #[test]
@@ -497,7 +501,7 @@ mod tests {
             provider_id,
             declaration_id,
             created: 0,
-            rewarded: None,
+            active: None,
             withdrawn: None,
         };
 
@@ -529,7 +533,7 @@ mod tests {
             provider_id,
             declaration_id,
             created: 0,
-            rewarded: None,
+            active: None,
             withdrawn: None,
         };
 
@@ -538,7 +542,7 @@ mod tests {
             ProviderState::try_from_info(100, &provider_info, &service_params).unwrap();
 
         let active_state = inactive_state
-            .try_into_active(105, EventType::Reward)
+            .try_into_active(105, EventType::Activity)
             .unwrap();
 
         let withdrawn_state =
@@ -576,7 +580,7 @@ mod tests {
             lock_period: 20,
             inactivity_period: 5,
             retention_period: 30,
-            reward_contract: [0; 32],
+            activity_contract: [0; 32],
             timestamp: 0,
         };
         let provider_info = ProviderInfo::new(0, provider_id, declaration_id);
@@ -592,7 +596,7 @@ mod tests {
     }
 
     #[test]
-    fn test_active_cannot_reward_directly_when_withdrawing() {
+    fn test_active_cannot_record_activity_directly_when_withdrawing() {
         let provider_id = ProviderId([0; 32]);
         let declaration_id = DeclarationId([1; 32]);
         let service_params = default_service_params();
@@ -603,9 +607,10 @@ mod tests {
             .try_into_active(0, EventType::Declaration)
             .unwrap();
 
-        // Attempt to transition to rewarded state without an intermediate step.
-        let rewarded_state = active_state.try_into_withdrawn(5, EventType::Reward, &service_params);
-        assert!(rewarded_state.is_err());
+        // Attempt to transition to active recorded state without an intermediate step.
+        let active_recorded_state =
+            active_state.try_into_withdrawn(5, EventType::Activity, &service_params);
+        assert!(active_recorded_state.is_err());
     }
 
     #[test]

--- a/nomos-services/sdp/src/adapters/rewards/mod.rs
+++ b/nomos-services/sdp/src/adapters/rewards/mod.rs
@@ -1,5 +1,5 @@
 use nomos_sdp_core::ledger;
 
-pub trait SdpRewardsAdapter: ledger::RewardsRequestSender {
+pub trait SdpRewardsAdapter: ledger::ActivityContract {
     fn new() -> Self;
 }

--- a/nomos-services/sdp/src/adapters/services/mod.rs
+++ b/nomos-services/sdp/src/adapters/services/mod.rs
@@ -1,5 +1,5 @@
 use nomos_sdp_core::ledger;
 
-pub trait SdpServicesAdapter: ledger::RewardsRequestSender {
+pub trait SdpServicesAdapter: ledger::ActivityContract {
     fn new() -> Self;
 }

--- a/nomos-services/sdp/src/backends/ledger.rs
+++ b/nomos-services/sdp/src/backends/ledger.rs
@@ -4,8 +4,8 @@ use nomos_sdp_core::{
     ledger::{
         SdpLedger,
         SdpLedgerError::{
-            self, DeclarationsRepository, DuplicateDeclarationInBlock, DuplicateServiceDeclaration,
-            Other, ProviderState, RewardsSender, ServiceNotProvided,
+            self, ActivityContract, DeclarationsRepository, DuplicateDeclarationInBlock,
+            DuplicateServiceDeclaration, Other, ProviderState, ServiceNotProvided,
             ServicesRepository as LedgerServicesRepository, StakesVerifier, WrongDeclarationId,
         },
         ServicesRepository,
@@ -84,7 +84,7 @@ where
         match e {
             ProviderState(provider_state_error) => Self::Other(Box::new(provider_state_error)),
             DeclarationsRepository(err) => Self::DeclarationAdapterError(Box::new(err)),
-            RewardsSender(err) => Self::RewardsAdapterError(Box::new(err)),
+            ActivityContract(err) => Self::RewardsAdapterError(Box::new(err)),
             LedgerServicesRepository(err) => Self::ServicesAdapterError(Box::new(err)),
             StakesVerifier(err) => Self::StakesVerifierAdapterError(Box::new(err)),
             DuplicateServiceDeclaration

--- a/nomos-services/sdp/src/lib.rs
+++ b/nomos-services/sdp/src/lib.rs
@@ -129,7 +129,7 @@ where
         + Sync
         + 'static,
     DeclarationAdapter: ledger::DeclarationsRepository + SdpDeclarationAdapter + Send + Sync,
-    RewardsAdapter: ledger::RewardsRequestSender<ContractAddress = ContractAddress, Metadata = Metadata>
+    RewardsAdapter: ledger::ActivityContract<ContractAddress = ContractAddress, Metadata = Metadata>
         + SdpRewardsAdapter
         + Send
         + Sync,

--- a/tests/src/tests/da/disperse.rs
+++ b/tests/src/tests/da/disperse.rs
@@ -138,10 +138,10 @@ async fn four_subnets_disseminate_retrieve_reconstruct() {
     let app_id = hex::decode(APP_ID).unwrap();
     let app_id: [u8; 32] = app_id.clone().try_into().unwrap();
 
-    let data = [1u8; 31 * ITERATIONS];
+    let data = [1u8; 837];
 
     for i in 0..ITERATIONS {
-        let data_size = 31 * (i + 1);
+        // let data_size = 31 * (i + 1);
         println!("disseminating {data_size} bytes");
         let data = &data[..data_size]; // test increasing size data
         let metadata = kzgrs_backend::dispersal::Metadata::new(app_id, Index::from(i as u64));

--- a/tests/src/tests/da/disperse.rs
+++ b/tests/src/tests/da/disperse.rs
@@ -138,10 +138,10 @@ async fn four_subnets_disseminate_retrieve_reconstruct() {
     let app_id = hex::decode(APP_ID).unwrap();
     let app_id: [u8; 32] = app_id.clone().try_into().unwrap();
 
-    let data = [1u8; 837];
+    let data = [1u8; 31 * ITERATIONS];
 
     for i in 0..ITERATIONS {
-        // let data_size = 31 * (i + 1);
+        let data_size = 31 * (i + 1);
         println!("disseminating {data_size} bytes");
         let data = &data[..data_size]; // test increasing size data
         let metadata = kzgrs_backend::dispersal::Metadata::new(app_id, Index::from(i as u64));


### PR DESCRIPTION
## 1. What does this PR implement?

SDP specification removed Reward and introduced Activity message. Now withdrawal can't claim reward, and in turn it can't declare activity after it already declared the withdrawal (even in the same block).

## 2. Does the code have enough context to be clearly understood?

[Spec](https://www.notion.so/Service-Declaration-Protocol-Specification-17b8f96fb65c80c69c2ef55e22e29506)

## 3. Who are the specification authors and who is accountable for this PR?

@madxor @bacv 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
