### PR TITLE
fix(docs): block api call get -> post

### DIFF
--- a/nodes/nomos-node/node/src/api/handlers.rs
+++ b/nodes/nomos-node/node/src/api/handlers.rs
@@ -560,7 +560,7 @@ where
 }
 
 #[utoipa::path(
-    get,
+    post,
     path = paths::STORAGE_BLOCK,
     responses(
         (status = 200, description = "Get the block by block id", body = HeaderId),


### PR DESCRIPTION
## 1. What does this PR implement?

Minor fix for the block api call docs. The doc listed a call as get, while it is post.



* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
