### PR TITLE
feat: integrate fork pruning in cryptarchia service

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -297,8 +297,15 @@ where
     /// stemming from the genesis block, with height `0`, which is the 11th
     /// block in the past.
     ///
-    /// It returns the number of fork tips that were removed.
-    pub fn prune_forks(&mut self, depth: u64) -> usize {
+    /// This function does not apply any particular logic when evaluating forks
+    /// other than the height at which they started diverging from the local
+    /// canonical chain.
+    ///
+    /// It returns the blocks that were part of the pruned forks. The order of
+    /// the branches is given by the underlying block storage, but branches
+    /// belonging to the same branch will appear from most recent to least
+    /// recent in the same order they were applied.
+    pub fn prune_forks(&mut self, depth: u64) -> impl Iterator<Item = Branch<Id>> {
         let local_chain = self.local_chain;
         let non_canonical_forks = self.non_canonical_forks();
         let Some(target_height) = local_chain.length.checked_sub(depth) else {
@@ -306,7 +313,7 @@ where
                 target: LOG_TARGET,
                 "No pruning needed, the canonical chain is not longer than the provided depth. Canonical chain length: {}, provided depth: {}", local_chain.length, depth
             );
-            return 0;
+            return vec![].into_iter();
         };
         // Calculate LCA between each fork and canonical chain, and consider for pruning
         // if the fork started before the specified `depth`.
@@ -317,32 +324,38 @@ where
                     (lca.length <= target_height).then_some((fork, lca))
                 })
                 .collect();
+        let mut removed_blocks = vec![];
         for (fork, lca) in &non_canonical_forks_older_than_depth {
-            self.prune_fork(fork.id, lca.id);
+            removed_blocks.extend(self.prune_fork(fork.id, lca.id));
         }
-        non_canonical_forks_older_than_depth.len()
+        removed_blocks.into_iter()
     }
 
-    /// Remove the list of blocks from `tip` to and excluding `up_to`.
-    fn prune_fork(&mut self, tip: Id, up_to: Id) {
+    /// Remove the list of blocks from `tip` to and excluding `up_to`, returning
+    /// them in the same order they were encounter while traversing blocks from
+    /// `tip` to `up_to`.
+    fn prune_fork(&mut self, tip: Id, up_to: Id) -> impl Iterator<Item = Branch<Id>> {
         let tip_removed = self.branches.tips.remove(&tip);
         assert!(
             tip_removed,
             "Provided fork tip should be in the set of tips"
         );
         let mut current_tip = tip;
+        let mut removed_blocks = vec![];
         while current_tip != up_to {
-            let Some(Branch { parent, .. }) = self.branches.branches.remove(&current_tip) else {
+            let Some(branch) = self.branches.branches.remove(&current_tip) else {
                 // If tip is not in branch set, it means this tip was sharing part of its
                 // history with another fork that has already been removed.
                 break;
             };
-            current_tip = parent;
+            removed_blocks.push(branch);
+            current_tip = branch.parent;
         }
         tracing::debug!(
             target: LOG_TARGET,
             "Pruned branch from {tip:#?} to {up_to:#?}."
         );
+        removed_blocks.into_iter()
     }
 
     pub const fn genesis(&self) -> Id {
@@ -408,6 +421,7 @@ where
 #[cfg(test)]
 pub mod tests {
     use std::{
+        collections::HashSet,
         hash::{DefaultHasher, Hash, Hasher as _},
         num::NonZero,
     };
@@ -594,7 +608,7 @@ pub mod tests {
             .receive_block([100; 32], [0; 32], 1.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(50), 0);
+        assert_eq!(chain.prune_forks(50).count(), 0);
         assert_eq!(chain, chain_pre);
     }
 
@@ -605,7 +619,7 @@ pub mod tests {
             .receive_block([100; 32], hash(&40u64), 41.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(10), 0);
+        assert_eq!(chain.prune_forks(10).count(), 0);
         assert_eq!(chain, chain_pre);
     }
 
@@ -613,11 +627,11 @@ pub mod tests {
     fn pruning_with_no_forks() {
         let chain_pre = create_canonical_chain(50.try_into().unwrap(), None);
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(50), 0);
+        assert_eq!(chain.prune_forks(50).count(), 0);
         assert_eq!(chain, chain_pre);
-        assert_eq!(chain.prune_forks(49), 0);
+        assert_eq!(chain.prune_forks(49).count(), 0);
         assert_eq!(chain, chain_pre);
-        assert_eq!(chain.prune_forks(51), 0);
+        assert_eq!(chain.prune_forks(51).count(), 0);
         assert_eq!(chain, chain_pre);
     }
 
@@ -631,8 +645,11 @@ pub mod tests {
             .receive_block([101; 32], hash(&40u64), 41.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(10), 1);
-        // Fork at block 39 was pruned.
+        let pruned_blocks = chain.prune_forks(10);
+        assert_eq!(
+            pruned_blocks.map(|block| block.id).collect::<HashSet<_>>(),
+            [[100; 32]].into()
+        );
         assert!(chain_pre.branches.tips.contains(&[100; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));
         assert!(!chain.branches.tips.contains(&[100; 32]));
@@ -657,7 +674,11 @@ pub mod tests {
             .receive_block([101; 32], hash(&40u64), 41.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(10), 2);
+        let pruned_blocks = chain.prune_forks(10);
+        assert_eq!(
+            pruned_blocks.map(|block| block.id).collect::<HashSet<_>>(),
+            [[100; 32], [200; 32]].into()
+        );
         // First fork at block 39 was pruned.
         assert!(chain_pre.branches.tips.contains(&[100; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));
@@ -687,7 +708,11 @@ pub mod tests {
             .receive_block([200; 32], [100; 32], 42.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(10), 2);
+        let pruned_blocks = chain.prune_forks(10);
+        assert_eq!(
+            pruned_blocks.map(|block| block.id).collect::<HashSet<_>>(),
+            [[100; 32], [101; 32], [200; 32]].into()
+        );
         // First fork was pruned entirely (both tips were removed).
         assert!(chain_pre.branches.tips.contains(&[101; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -65,6 +65,8 @@ type SamplingRelay<BlobId> = OutboundRelay<DaSamplingServiceMsg<BlobId>>;
 const HEADERS_LIMIT: usize = 512;
 const CRYPTARCHIA_ID: &str = "Cryptarchia";
 
+pub(crate) const LOG_TARGET: &str = "cryptarchia-consensus";
+
 #[derive(Debug, Clone, Error)]
 pub enum Error {
     #[error("Ledger error: {0}")]
@@ -183,7 +185,7 @@ impl Cryptarchia {
     }
 
     pub fn prune_old_forks(&mut self) {
-        self.consensus.prune_forks(
+        let old_forks_pruned = self.consensus.prune_forks(
             self.ledger
                 .config()
                 .consensus_config
@@ -191,6 +193,7 @@ impl Cryptarchia {
                 .get()
                 .into(),
         );
+        tracing::debug!(target: LOG_TARGET, "Pruned {old_forks_pruned} old forks");
     }
 }
 

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -193,7 +193,7 @@ impl Cryptarchia {
                 .get()
                 .into(),
         );
-        tracing::debug!(target: LOG_TARGET, "Pruned {old_forks_pruned} old forks");
+        tracing::debug!(target: LOG_TARGET, "Pruned {} old forks", old_forks_pruned.count());
     }
 }
 

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -74,7 +74,7 @@ pub enum Error {
 }
 
 struct Cryptarchia {
-    ledger: nomos_ledger::Ledger<HeaderId>,
+    ledger: nomos_ledger::Ledger<HeaderId>,  
     consensus: cryptarchia_engine::Cryptarchia<HeaderId>,
 }
 
@@ -180,6 +180,10 @@ impl Cryptarchia {
         } else {
             None
         }
+    }
+
+    pub fn prune_old_forks(&mut self) {
+        self.consensus.prune_forks(self.ledger.config().consensus_config.security_param.get().into());
     }
 }
 
@@ -564,7 +568,7 @@ where
             blob_selector_settings,
             leader_config,
             network_adapter_settings,
-            blend_adapter_settings,
+            blend_adapter_settings, 
             ..
         } = self.service_state.settings_reader.get_updated_settings();
 
@@ -618,6 +622,7 @@ where
                         .await;
 
                         self.service_state.state_updater.update(Self::State::from_cryptarchia(&cryptarchia, &leader));
+                        cryptarchia.prune_old_forks();
 
                         tracing::info!(counter.consensus_processed_blocks = 1);
                     }


### PR DESCRIPTION
## 1. What does this PR implement?

> **PARKED FOR NOW, AS THE FORK-CHOICE RULE IS GETTING UPDATED. THIS WILL BE PICKED UP ONCE WE HAVE A NEW SPECIFICATION FOR THE NEW FORK CHOICE RULE**.

Builds on top of https://github.com/logos-co/nomos/pull/1262.

It integrates the new `prune_forks` function of the cryptarchia consensus engine in two instances: when the node appends a new block to its local canonical chain, or when the node applies a new block and after it applies its own fork-choice rule. The in-memory storage is pruned after any relevant state is stored according to the `StateOperator` logic. This means that the forks are not pruned when the state is being restored or during bootstrapping/recovery processes, but all forks created during those processes will be trimmed as soon as a new block is appended to the canonical chain. If the canonical chain were to change after the execution of the fork-choice rule, than the old canonical chain will remain in memory until its divergence point becomes older than `k`, after which it will be eliminated from in-memory storage.

Furthermore, interactions with persistent storage which happens within the `process_block_unchecked` function are not altered as part of this PR, which is only concerned about memory-loaded blocks.

The `prune_forks` is always called with the parameter `k`, meaning that every time the canonical chain is extended by one, the logic will remove any forks that are older than that.

Additionally, I introduced logic to add a locally-produced block to the local chain before pushing it out to peers, as this was missing before.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
