### PR TITLE
feat: return pruned block info from cryptarchia engine

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -297,8 +297,15 @@ where
     /// stemming from the genesis block, with height `0`, which is the 11th
     /// block in the past.
     ///
-    /// It returns the number of fork tips that were removed.
-    pub fn prune_forks(&mut self, depth: u64) -> usize {
+    /// This function does not apply any particular logic when evaluating forks
+    /// other than the height at which they started diverging from the local
+    /// canonical chain.
+    ///
+    /// It returns the blocks that were part of the pruned forks. The order of
+    /// the branches is given by the underlying block storage, but branches
+    /// belonging to the same branch will appear from most recent to least
+    /// recent in the same order they were applied.
+    pub fn prune_forks(&mut self, depth: u64) -> impl Iterator<Item = Branch<Id>> {
         let local_chain = self.local_chain;
         let non_canonical_forks = self.non_canonical_forks();
         let Some(target_height) = local_chain.length.checked_sub(depth) else {
@@ -306,7 +313,7 @@ where
                 target: LOG_TARGET,
                 "No pruning needed, the canonical chain is not longer than the provided depth. Canonical chain length: {}, provided depth: {}", local_chain.length, depth
             );
-            return 0;
+            return vec![].into_iter();
         };
         // Calculate LCA between each fork and canonical chain, and consider for pruning
         // if the fork started before the specified `depth`.
@@ -317,32 +324,38 @@ where
                     (lca.length <= target_height).then_some((fork, lca))
                 })
                 .collect();
+        let mut removed_blocks = vec![];
         for (fork, lca) in &non_canonical_forks_older_than_depth {
-            self.prune_fork(fork.id, lca.id);
+            removed_blocks.extend(self.prune_fork(fork.id, lca.id));
         }
-        non_canonical_forks_older_than_depth.len()
+        removed_blocks.into_iter()
     }
 
-    /// Remove the list of blocks from `tip` to and excluding `up_to`.
-    fn prune_fork(&mut self, tip: Id, up_to: Id) {
+    /// Remove the list of blocks from `tip` to and excluding `up_to`, returning
+    /// them in the same order they were encounter while traversing blocks from
+    /// `tip` to `up_to`.
+    fn prune_fork(&mut self, tip: Id, up_to: Id) -> impl Iterator<Item = Branch<Id>> {
         let tip_removed = self.branches.tips.remove(&tip);
         assert!(
             tip_removed,
             "Provided fork tip should be in the set of tips"
         );
         let mut current_tip = tip;
+        let mut removed_blocks = vec![];
         while current_tip != up_to {
-            let Some(Branch { parent, .. }) = self.branches.branches.remove(&current_tip) else {
+            let Some(branch) = self.branches.branches.remove(&current_tip) else {
                 // If tip is not in branch set, it means this tip was sharing part of its
                 // history with another fork that has already been removed.
                 break;
             };
-            current_tip = parent;
+            removed_blocks.push(branch);
+            current_tip = branch.parent;
         }
         tracing::debug!(
             target: LOG_TARGET,
             "Pruned branch from {tip:#?} to {up_to:#?}."
         );
+        removed_blocks.into_iter()
     }
 
     pub const fn genesis(&self) -> Id {
@@ -408,6 +421,7 @@ where
 #[cfg(test)]
 pub mod tests {
     use std::{
+        collections::HashSet,
         hash::{DefaultHasher, Hash, Hasher as _},
         num::NonZero,
     };
@@ -594,7 +608,7 @@ pub mod tests {
             .receive_block([100; 32], [0; 32], 1.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(50), 0);
+        assert_eq!(chain.prune_forks(50).count(), 0);
         assert_eq!(chain, chain_pre);
     }
 
@@ -605,7 +619,7 @@ pub mod tests {
             .receive_block([100; 32], hash(&40u64), 41.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(10), 0);
+        assert_eq!(chain.prune_forks(10).count(), 0);
         assert_eq!(chain, chain_pre);
     }
 
@@ -613,11 +627,11 @@ pub mod tests {
     fn pruning_with_no_forks() {
         let chain_pre = create_canonical_chain(50.try_into().unwrap(), None);
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(50), 0);
+        assert_eq!(chain.prune_forks(50).count(), 0);
         assert_eq!(chain, chain_pre);
-        assert_eq!(chain.prune_forks(49), 0);
+        assert_eq!(chain.prune_forks(49).count(), 0);
         assert_eq!(chain, chain_pre);
-        assert_eq!(chain.prune_forks(51), 0);
+        assert_eq!(chain.prune_forks(51).count(), 0);
         assert_eq!(chain, chain_pre);
     }
 
@@ -631,8 +645,11 @@ pub mod tests {
             .receive_block([101; 32], hash(&40u64), 41.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(10), 1);
-        // Fork at block 39 was pruned.
+        let pruned_blocks = chain.prune_forks(10);
+        assert_eq!(
+            pruned_blocks.map(|block| block.id).collect::<HashSet<_>>(),
+            [[100; 32]].into()
+        );
         assert!(chain_pre.branches.tips.contains(&[100; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));
         assert!(!chain.branches.tips.contains(&[100; 32]));
@@ -657,7 +674,11 @@ pub mod tests {
             .receive_block([101; 32], hash(&40u64), 41.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(10), 2);
+        let pruned_blocks = chain.prune_forks(10);
+        assert_eq!(
+            pruned_blocks.map(|block| block.id).collect::<HashSet<_>>(),
+            [[100; 32], [200; 32]].into()
+        );
         // First fork at block 39 was pruned.
         assert!(chain_pre.branches.tips.contains(&[100; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));
@@ -687,7 +708,11 @@ pub mod tests {
             .receive_block([200; 32], [100; 32], 42.into())
             .expect("test block to be applied successfully.");
         let mut chain = chain_pre.clone();
-        assert_eq!(chain.prune_forks(10), 2);
+        let pruned_blocks = chain.prune_forks(10);
+        assert_eq!(
+            pruned_blocks.map(|block| block.id).collect::<HashSet<_>>(),
+            [[100; 32], [101; 32], [200; 32]].into()
+        );
         // First fork was pruned entirely (both tips were removed).
         assert!(chain_pre.branches.tips.contains(&[101; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -193,7 +193,7 @@ impl Cryptarchia {
                 .get()
                 .into(),
         );
-        tracing::debug!(target: LOG_TARGET, "Pruned {old_forks_pruned} old forks");
+        tracing::debug!(target: LOG_TARGET, "Pruned {} old forks", old_forks_pruned.count());
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

WIP. Built on top of https://github.com/logos-co/nomos/pull/1262.

I will add more details if this PR becomes relevant, but for now it suffices to say that I am playing around with returning information about the pruned blocks from cryptarchia. This can be used by the cryptarchia service to then delete those blocks from the persistent storage.

What this PR does not do (yet) is:

1. Conditionally delete old forks only if they have been tested for density, sparing the ones that are old but not long enough (following the current fork choice rule which is undergoing a refactoring)
2. Retrieve missing blocks from storage if not found in memory before triggering backfilling. This is also conditional to the fork choice rule being updated, as old forks might be considered invalid past `k`, simplifying this process a lot.

## Ideas for improvement

We can slightly refactor `Cryptarchia` to support one of the states it is in. We can then expose two different `prune_forks` implementations depending on whether the engine is still bootstrapping or is up to date. In the former case, we should only remove old forks if they fail the density check, while in the latter we remove them regardless, as per the [updated spec](https://www.notion.so/Cryptarchia-Fork-Choice-Rule-14f8f96fb65c804986dff0565e8fdc54).

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No, but it is dependent on some not-yet-finalized spec changes.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
