### PR TITLE
ci: Use linux label for self-hosted runner

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -167,7 +167,9 @@ jobs:
     strategy:
       fail-fast: false # all OSes should be tested even if one fails (default: true)
       matrix:
-        os: [ self-hosted, macos-latest ]
+        os:
+          - [self-hosted, Linux]
+          - [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## 1. What does this PR implement?

`self-hosted` label might pickup either linux or macos runner, to run tests on different platforms `linux` label was added when running on self-hosted, for macos jobs the github runner is used.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@bacv

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
