### PR TITLE
Storage Conversion trait

### DIFF
--- a/nodes/nomos-executor/executor/src/lib.rs
+++ b/nodes/nomos-executor/executor/src/lib.rs
@@ -18,8 +18,11 @@ use nomos_da_dispersal::{
 };
 use nomos_da_network_service::backends::libp2p::executor::DaNetworkExecutorBackend;
 use nomos_da_sampling::{
-    api::http::HttApiAdapter, backend::kzgrs::KzgrsSamplingBackend,
-    storage::adapters::rocksdb::RocksAdapter as SamplingStorageAdapter,
+    api::http::HttApiAdapter,
+    backend::kzgrs::KzgrsSamplingBackend,
+    storage::adapters::{
+        converter::DaStorageConverter, rocksdb::RocksAdapter as SamplingStorageAdapter,
+    },
 };
 use nomos_da_verifier::{
     backend::kzgrs::KzgrsDaVerifier,
@@ -57,10 +60,10 @@ type DispersalMempoolAdapter = KzgrsMempoolAdapter<
         RuntimeServiceId,
     >,
     ChaCha20Rng,
-    SamplingStorageAdapter<DaShare, Wire>,
+    SamplingStorageAdapter<DaShare, Wire, DaStorageConverter>,
     KzgrsDaVerifier,
     VerifierNetworkAdapter<NomosDaMembership, RuntimeServiceId>,
-    VerifierStorageAdapter<DaShare, Wire>,
+    VerifierStorageAdapter<DaShare, Wire, DaStorageConverter>,
     HttApiAdapter<NomosDaMembership>,
     RuntimeServiceId,
 >;
@@ -141,9 +144,10 @@ pub(crate) type ApiService = nomos_api::ApiService<
         BlobInfo,
         KzgrsDaVerifier,
         VerifierNetworkAdapter<NomosDaMembership, RuntimeServiceId>,
-        VerifierStorageAdapter<DaShare, Wire>,
+        VerifierStorageAdapter<DaShare, Wire, DaStorageConverter>,
         Tx,
         Wire,
+        DaStorageConverter,
         DispersalKZGRSBackend<
             DispersalNetworkAdapter<NomosDaMembership, RuntimeServiceId>,
             DispersalMempoolAdapter,
@@ -157,7 +161,7 @@ pub(crate) type ApiService = nomos_api::ApiService<
             RuntimeServiceId,
         >,
         ChaCha20Rng,
-        SamplingStorageAdapter<DaShare, Wire>,
+        SamplingStorageAdapter<DaShare, Wire, DaStorageConverter>,
         NtpTimeBackend,
         HttApiAdapter<NomosDaMembership>,
         ApiStorageAdapter<Wire, RuntimeServiceId>,

--- a/nodes/nomos-node/node/src/generic_services.rs
+++ b/nodes/nomos-node/node/src/generic_services.rs
@@ -2,7 +2,10 @@ use cryptarchia_consensus::CryptarchiaConsensus;
 use kzgrs_backend::{common::share::DaShare, dispersal::BlobInfo};
 use nomos_core::{da::blob::info::DispersedBlobInfo, header::HeaderId, tx::Transaction};
 use nomos_da_indexer::consensus::adapters::cryptarchia::CryptarchiaConsensusAdapter;
-use nomos_da_sampling::{api::http::HttApiAdapter, backend::kzgrs::KzgrsSamplingBackend};
+use nomos_da_sampling::{
+    api::http::HttApiAdapter, backend::kzgrs::KzgrsSamplingBackend,
+    storage::adapters::converter::DaStorageConverter,
+};
 use nomos_da_verifier::backend::kzgrs::KzgrsDaVerifier;
 use nomos_mempool::backend::mockpool::MockPool;
 use nomos_storage::backends::rocksdb::RocksBackend;
@@ -27,7 +30,11 @@ pub type DaIndexerService<SamplingAdapter, VerifierNetwork, RuntimeServiceId> =
     nomos_da_indexer::DataIndexerService<
         // Indexer specific.
         DaShare,
-        nomos_da_indexer::storage::adapters::rocksdb::RocksAdapter<Wire, BlobInfo>,
+        nomos_da_indexer::storage::adapters::rocksdb::RocksAdapter<
+            Wire,
+            BlobInfo,
+            DaStorageConverter,
+        >,
         CryptarchiaConsensusAdapter<Tx, BlobInfo>,
         // Cryptarchia specific, should be the same as in `Cryptarchia` type above.
         cryptarchia_consensus::network::adapters::libp2p::LibP2pAdapter<
@@ -59,10 +66,18 @@ pub type DaIndexerService<SamplingAdapter, VerifierNetwork, RuntimeServiceId> =
         KzgrsSamplingBackend<ChaCha20Rng>,
         SamplingAdapter,
         ChaCha20Rng,
-        nomos_da_sampling::storage::adapters::rocksdb::RocksAdapter<DaShare, Wire>,
+        nomos_da_sampling::storage::adapters::rocksdb::RocksAdapter<
+            DaShare,
+            Wire,
+            DaStorageConverter,
+        >,
         KzgrsDaVerifier,
         VerifierNetwork,
-        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<DaShare, Wire>,
+        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<
+            DaShare,
+            Wire,
+            DaStorageConverter,
+        >,
         NtpTimeBackend,
         HttApiAdapter<NomosDaMembership>,
         RuntimeServiceId,
@@ -72,7 +87,11 @@ pub type DaVerifierService<VerifierAdapter, RuntimeServiceId> =
     nomos_da_verifier::DaVerifierService<
         KzgrsDaVerifier,
         VerifierAdapter,
-        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<DaShare, Wire>,
+        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<
+            DaShare,
+            Wire,
+            DaStorageConverter,
+        >,
         RuntimeServiceId,
     >;
 
@@ -81,10 +100,18 @@ pub type DaSamplingService<SamplingAdapter, VerifierNetworkAdapter, RuntimeServi
         KzgrsSamplingBackend<ChaCha20Rng>,
         SamplingAdapter,
         ChaCha20Rng,
-        nomos_da_sampling::storage::adapters::rocksdb::RocksAdapter<DaShare, Wire>,
+        nomos_da_sampling::storage::adapters::rocksdb::RocksAdapter<
+            DaShare,
+            Wire,
+            DaStorageConverter,
+        >,
         KzgrsDaVerifier,
         VerifierNetworkAdapter,
-        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<DaShare, Wire>,
+        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<
+            DaShare,
+            Wire,
+            DaStorageConverter,
+        >,
         HttApiAdapter<NomosDaMembership>,
         RuntimeServiceId,
     >;
@@ -100,10 +127,18 @@ pub type DaMempoolService<DaSamplingNetwork, VerifierNetwork, RuntimeServiceId> 
         KzgrsSamplingBackend<ChaCha20Rng>,
         DaSamplingNetwork,
         ChaCha20Rng,
-        nomos_da_sampling::storage::adapters::rocksdb::RocksAdapter<DaShare, Wire>,
+        nomos_da_sampling::storage::adapters::rocksdb::RocksAdapter<
+            DaShare,
+            Wire,
+            DaStorageConverter,
+        >,
         KzgrsDaVerifier,
         VerifierNetwork,
-        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<DaShare, Wire>,
+        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<
+            DaShare,
+            Wire,
+            DaStorageConverter,
+        >,
         HttApiAdapter<NomosDaMembership>,
         RuntimeServiceId,
     >;
@@ -139,10 +174,18 @@ pub type CryptarchiaService<SamplingAdapter, VerifierNetwork, RuntimeServiceId> 
         KzgrsSamplingBackend<ChaCha20Rng>,
         SamplingAdapter,
         ChaCha20Rng,
-        nomos_da_sampling::storage::adapters::rocksdb::RocksAdapter<DaShare, Wire>,
+        nomos_da_sampling::storage::adapters::rocksdb::RocksAdapter<
+            DaShare,
+            Wire,
+            DaStorageConverter,
+        >,
         KzgrsDaVerifier,
         VerifierNetwork,
-        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<DaShare, Wire>,
+        nomos_da_verifier::storage::adapters::rocksdb::RocksAdapter<
+            DaShare,
+            Wire,
+            DaStorageConverter,
+        >,
         NtpTimeBackend,
         HttApiAdapter<NomosDaMembership>,
         RuntimeServiceId,

--- a/nodes/nomos-node/node/src/lib.rs
+++ b/nodes/nomos-node/node/src/lib.rs
@@ -19,9 +19,12 @@ pub use nomos_core::{
 };
 pub use nomos_da_network_service::backends::libp2p::validator::DaNetworkValidatorBackend;
 use nomos_da_sampling::{
-    api::http::HttApiAdapter, backend::kzgrs::KzgrsSamplingBackend,
+    api::http::HttApiAdapter,
+    backend::kzgrs::KzgrsSamplingBackend,
     network::adapters::validator::Libp2pAdapter as SamplingLibp2pAdapter,
-    storage::adapters::rocksdb::RocksAdapter as SamplingStorageAdapter,
+    storage::adapters::{
+        converter::DaStorageConverter, rocksdb::RocksAdapter as SamplingStorageAdapter,
+    },
 };
 use nomos_da_verifier::{
     backend::kzgrs::KzgrsDaVerifier,
@@ -146,16 +149,17 @@ pub(crate) type ApiService = nomos_api::ApiService<
         BlobInfo,
         KzgrsDaVerifier,
         VerifierNetworkAdapter<NomosDaMembership, RuntimeServiceId>,
-        VerifierStorageAdapter<DaShare, Wire>,
+        VerifierStorageAdapter<DaShare, Wire, DaStorageConverter>,
         Tx,
         Wire,
+        DaStorageConverter,
         KzgrsSamplingBackend<ChaCha20Rng>,
         nomos_da_sampling::network::adapters::validator::Libp2pAdapter<
             NomosDaMembership,
             RuntimeServiceId,
         >,
         ChaCha20Rng,
-        SamplingStorageAdapter<DaShare, Wire>,
+        SamplingStorageAdapter<DaShare, Wire, DaStorageConverter>,
         NtpTimeBackend,
         HttApiAdapter<NomosDaMembership>,
         ApiStorageAdapter<Wire, RuntimeServiceId>,

--- a/nomos-da/kzgrs-backend/Cargo.toml
+++ b/nomos-da/kzgrs-backend/Cargo.toml
@@ -11,7 +11,6 @@ ark-ff        = "0.4"
 ark-poly      = "0.4.2"
 ark-serialize = "0.4.2"
 blake2        = "0.10"
-bytes         = { workspace = true }
 itertools     = "0.12"
 kzgrs         = { workspace = true }
 nomos-core    = { workspace = true }

--- a/nomos-da/kzgrs-backend/src/common/share.rs
+++ b/nomos-da/kzgrs-backend/src/common/share.rs
@@ -1,6 +1,5 @@
-use bytes::Bytes;
 use kzgrs::Proof;
-use nomos_core::{da::blob, wire};
+use nomos_core::da::blob;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest as _, Sha3_256};
 
@@ -113,11 +112,4 @@ pub struct DaSharesCommitments {
         deserialize_with = "deserialize_vec_canonical"
     )]
     pub rows_commitments: Vec<Commitment>,
-}
-
-impl TryFrom<Bytes> for DaLightShare {
-    type Error = wire::Error;
-    fn try_from(value: Bytes) -> Result<Self, Self::Error> {
-        wire::deserialize(&value)
-    }
 }

--- a/nomos-services/api/src/http/da.rs
+++ b/nomos-services/api/src/http/da.rs
@@ -32,7 +32,9 @@ use nomos_da_network_service::{
     },
     DaNetworkMsg, NetworkService,
 };
-use nomos_da_sampling::backend::DaSamplingServiceBackend;
+use nomos_da_sampling::{
+    backend::DaSamplingServiceBackend, storage::adapters::converter::DaStorageConverter,
+};
 use nomos_da_verifier::{
     backend::VerifierBackend, storage::adapters::rocksdb::RocksAdapter as VerifierStorageAdapter,
     DaVerifierMsg, DaVerifierService,
@@ -41,7 +43,10 @@ use nomos_libp2p::PeerId;
 use nomos_mempool::{
     backend::mockpool::MockPool, network::adapters::libp2p::Libp2pAdapter as MempoolNetworkAdapter,
 };
-use nomos_storage::backends::{rocksdb::RocksBackend, StorageSerde};
+use nomos_storage::{
+    api::da::DaConverter,
+    backends::{rocksdb::RocksBackend, StorageSerde},
+};
 use overwatch::{overwatch::handle::OverwatchHandle, services::AsServiceId, DynError};
 use rand::{RngCore, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -69,7 +74,7 @@ pub type DaIndexer<
 > = DataIndexerService<
     // Indexer specific.
     DaShare,
-    IndexerStorageAdapter<SS, V>,
+    IndexerStorageAdapter<SS, V, DaStorageConverter>,
     CryptarchiaConsensusAdapter<Tx, V>,
     // Cryptarchia specific, should be the same as in `Cryptarchia` type above.
     cryptarchia_consensus::network::adapters::libp2p::LibP2pAdapter<Tx, V, RuntimeServiceId>,
@@ -98,13 +103,19 @@ pub type DaIndexer<
     RuntimeServiceId,
 >;
 
-pub type DaVerifier<Blob, NetworkAdapter, VerifierBackend, StorageSerializer, RuntimeServiceId> =
-    DaVerifierService<
-        VerifierBackend,
-        NetworkAdapter,
-        VerifierStorageAdapter<Blob, StorageSerializer>,
-        RuntimeServiceId,
-    >;
+pub type DaVerifier<
+    Blob,
+    NetworkAdapter,
+    VerifierBackend,
+    StorageSerializer,
+    DaStorageConverter,
+    RuntimeServiceId,
+> = DaVerifierService<
+    VerifierBackend,
+    NetworkAdapter,
+    VerifierStorageAdapter<Blob, StorageSerializer, DaStorageConverter>,
+    RuntimeServiceId,
+>;
 
 pub type DaDispersal<
     Backend,
@@ -124,16 +135,15 @@ pub type DaDispersal<
 
 pub type DaNetwork<Backend, RuntimeServiceId> = NetworkService<Backend, RuntimeServiceId>;
 
-pub async fn add_share<A, S, N, VB, SS, RuntimeServiceId>(
+pub async fn add_share<A, S, N, VB, SS, DaStorageConverter, RuntimeServiceId>(
     handle: &OverwatchHandle<RuntimeServiceId>,
     share: S,
 ) -> Result<Option<()>, DynError>
 where
     A: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     S: Share + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-    <S as Share>::BlobId: AsRef<[u8]> + Send + Sync + 'static,
-    <S as Share>::ShareIndex:
-        AsRef<[u8]> + Serialize + DeserializeOwned + Eq + Hash + Send + Sync + 'static,
+    <S as Share>::BlobId: Clone + Send + Sync + 'static,
+    <S as Share>::ShareIndex: Clone + Eq + Hash + Send + Sync + 'static,
     <S as Share>::LightShare: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     <S as Share>::SharesCommitments: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     N: nomos_da_verifier::network::NetworkAdapter<RuntimeServiceId>,
@@ -142,8 +152,11 @@ where
     <VB as VerifierBackend>::Settings: Clone,
     <VB as CoreDaVerifier>::Error: Error,
     SS: StorageSerde + Send + Sync + 'static,
-    RuntimeServiceId:
-        Debug + Sync + Display + AsServiceId<DaVerifier<S, N, VB, SS, RuntimeServiceId>>,
+    DaStorageConverter: DaConverter<RocksBackend<SS>, Share = S> + Send + Sync + 'static,
+    RuntimeServiceId: Debug
+        + Sync
+        + Display
+        + AsServiceId<DaVerifier<S, N, VB, SS, DaStorageConverter, RuntimeServiceId>>,
 {
     let relay = handle.relay().await?;
     let (sender, receiver) = oneshot::channel();
@@ -218,6 +231,7 @@ where
     <V as metadata::Metadata>::Index:
         AsRef<[u8]> + Serialize + DeserializeOwned + Clone + PartialOrd + Send + Sync,
     SS: StorageSerde + Send + Sync + 'static,
+    <SS as StorageSerde>::Error: Error + Send + Sync,
     SamplingRng: SeedableRng + RngCore,
     SamplingBackend: DaSamplingServiceBackend<SamplingRng, BlobId = BlobId> + Send,
     SamplingBackend::Settings: Clone,

--- a/nomos-services/data-availability/sampling/Cargo.toml
+++ b/nomos-services/data-availability/sampling/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 async-trait              = "0.1"
+bytes                    = { workspace = true }
 common-http-client       = { workspace = true }
 futures                  = "0.3"
 hex                      = "0.4.3"

--- a/nomos-services/data-availability/sampling/src/lib.rs
+++ b/nomos-services/data-availability/sampling/src/lib.rs
@@ -273,7 +273,7 @@ where
             } => {
                 info_with_id!(blob_id, "SamplingRequest");
                 let maybe_share = storage_adapter
-                    .get_light_share(blob_id, share_idx)
+                    .get_light_share(blob_id, share_idx.to_be_bytes())
                     .await
                     .map_err(|error| {
                         error!("Failed to get share from storage adapter: {error}");

--- a/nomos-services/data-availability/sampling/src/storage/adapters/converter.rs
+++ b/nomos-services/data-availability/sampling/src/storage/adapters/converter.rs
@@ -1,0 +1,60 @@
+use bytes::Bytes;
+use kzgrs_backend::common::share::{DaLightShare, DaShare, DaSharesCommitments};
+use nomos_core::da::{blob::Share, BlobId};
+use nomos_storage::{
+    api::da::DaConverter,
+    backends::{rocksdb::RocksBackend, StorageSerde},
+};
+
+type ShareIndex = [u8; 2];
+
+pub struct DaStorageConverter;
+
+impl<SerdeOP> DaConverter<RocksBackend<SerdeOP>> for DaStorageConverter
+where
+    SerdeOP: StorageSerde + Send + Sync + 'static,
+    <SerdeOP as StorageSerde>::Error: Send + Sync + 'static,
+{
+    type Share = DaShare;
+    type Error = SerdeOP::Error;
+
+    fn blob_id_to_storage(blob_id: BlobId) -> Result<BlobId, Self::Error> {
+        Ok(blob_id)
+    }
+
+    fn blob_id_from_storage(blob_id: BlobId) -> Result<BlobId, Self::Error> {
+        Ok(blob_id)
+    }
+
+    fn share_index_to_storage(
+        share_index: <DaShare as Share>::ShareIndex,
+    ) -> Result<ShareIndex, Self::Error> {
+        Ok(share_index)
+    }
+
+    fn share_index_from_storage(
+        share_index: ShareIndex,
+    ) -> Result<<DaShare as Share>::ShareIndex, Self::Error> {
+        Ok(share_index)
+    }
+
+    fn share_to_storage(service_share: DaLightShare) -> Result<Bytes, Self::Error> {
+        Ok(SerdeOP::serialize(&service_share))
+    }
+
+    fn share_from_storage(backend_share: Bytes) -> Result<DaLightShare, Self::Error> {
+        SerdeOP::deserialize(backend_share)
+    }
+
+    fn commitments_to_storage(
+        service_commitments: DaSharesCommitments,
+    ) -> Result<Bytes, Self::Error> {
+        Ok(SerdeOP::serialize(&service_commitments))
+    }
+
+    fn commitments_from_storage(
+        backend_commitments: Bytes,
+    ) -> Result<DaSharesCommitments, Self::Error> {
+        SerdeOP::deserialize(backend_commitments)
+    }
+}

--- a/nomos-services/data-availability/sampling/src/storage/adapters/mod.rs
+++ b/nomos-services/data-availability/sampling/src/storage/adapters/mod.rs
@@ -1,2 +1,3 @@
+pub mod converter;
 #[cfg(feature = "rocksdb-backend")]
 pub mod rocksdb;

--- a/nomos-services/data-availability/sampling/src/storage/adapters/rocksdb.rs
+++ b/nomos-services/data-availability/sampling/src/storage/adapters/rocksdb.rs
@@ -1,8 +1,8 @@
 use std::{marker::PhantomData, path::PathBuf};
 
-use kzgrs_backend::common::ShareIndex;
 use nomos_core::da::blob::Share;
 use nomos_storage::{
+    api::da::DaConverter,
     backends::{rocksdb::RocksBackend, StorageSerde},
     StorageMsg, StorageService,
 };
@@ -14,24 +14,29 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::storage::DaStorageAdapter;
 
-pub struct RocksAdapter<B, S>
+pub struct RocksAdapter<B, S, Converter>
 where
     S: StorageSerde + Send + Sync + 'static,
 {
     storage_relay: OutboundRelay<StorageMsg<RocksBackend<S>>>,
     share: PhantomData<B>,
+    converter: PhantomData<Converter>,
 }
 
 #[async_trait::async_trait]
-impl<B, S, RuntimeServiceId> DaStorageAdapter<RuntimeServiceId> for RocksAdapter<B, S>
+impl<B, S, Converter, RuntimeServiceId> DaStorageAdapter<RuntimeServiceId>
+    for RocksAdapter<B, S, Converter>
 where
     S: StorageSerde + Send + Sync + 'static,
+    Converter: DaConverter<RocksBackend<S>, Share = B> + Send + Sync + 'static,
     B: Share + DeserializeOwned + Clone + Send + Sync + 'static,
+    B::BlobId: Send + Sync + 'static,
+    B::ShareIndex: Send + Sync + 'static,
     B::LightShare: DeserializeOwned + Clone + Send + Sync + 'static,
     B::SharesCommitments: DeserializeOwned + Clone + Send + Sync + 'static,
-    B::BlobId: AsRef<[u8]> + Send,
 {
     type Backend = RocksBackend<S>;
+
     type Share = B;
     type Settings = RocksAdapterSettings;
 
@@ -43,6 +48,7 @@ where
         Self {
             storage_relay,
             share: PhantomData,
+            converter: PhantomData,
         }
     }
 
@@ -52,19 +58,18 @@ where
     ) -> Result<Option<<Self::Share as Share>::SharesCommitments>, DynError> {
         let (sc_reply_tx, sc_reply_rx) = tokio::sync::oneshot::channel();
         self.storage_relay
-            .send(StorageMsg::get_shared_commitments_request(
-                blob_id
-                    .as_ref()
-                    .try_into()
-                    .expect("BlobId conversion should not fail"),
+            .send(StorageMsg::get_shared_commitments_request::<Converter>(
+                blob_id,
                 sc_reply_tx,
-            ))
+            )?)
             .await
             .expect("Failed to send load request to storage relay");
 
         let shared_commitments = sc_reply_rx.await?;
         let shared_commitments = shared_commitments
-            .map(|sc| S::deserialize(sc).expect("Failed to deserialize shared commitments"));
+            .map(|sc| Converter::commitments_from_storage(sc))
+            .transpose()
+            .map_err(DynError::from)?;
 
         Ok(shared_commitments)
     }
@@ -72,28 +77,23 @@ where
     async fn get_light_share(
         &self,
         blob_id: <Self::Share as Share>::BlobId,
-        share_idx: ShareIndex,
+        share_idx: <Self::Share as Share>::ShareIndex,
     ) -> Result<Option<<Self::Share as Share>::LightShare>, DynError> {
-        let blob_id = blob_id.as_ref().try_into().unwrap();
-        let share_idx = share_idx.to_be_bytes();
-
         let (reply_channel, reply_rx) = tokio::sync::oneshot::channel();
         self.storage_relay
-            .send(StorageMsg::get_light_share_request(
+            .send(StorageMsg::get_light_share_request::<Converter>(
                 blob_id,
                 share_idx,
                 reply_channel,
-            ))
+            )?)
             .await
             .expect("Failed to send request to storage relay");
 
-        reply_rx
-            .await
-            .map(|maybe_share| {
-                maybe_share
-                    .map(|share| S::deserialize(share).expect("Failed to deserialize light share"))
-            })
-            .map_err(|_| "Failed to receive response from storage".into())
+        let result = reply_rx.await.map_err(DynError::from)?;
+        result
+            .map(|data| Converter::share_from_storage(data))
+            .transpose()
+            .map_err(DynError::from)
     }
 }
 

--- a/nomos-services/data-availability/sampling/src/storage/mod.rs
+++ b/nomos-services/data-availability/sampling/src/storage/mod.rs
@@ -1,6 +1,5 @@
 pub mod adapters;
 
-use kzgrs_backend::common::ShareIndex;
 use nomos_core::da::blob::Share;
 use nomos_storage::{backends::StorageBackend, StorageService};
 use overwatch::{
@@ -27,6 +26,6 @@ pub trait DaStorageAdapter<RuntimeServiceId> {
     async fn get_light_share(
         &self,
         blob_id: <Self::Share as Share>::BlobId,
-        share_idx: ShareIndex,
+        share_idx: <Self::Share as Share>::ShareIndex,
     ) -> Result<Option<<Self::Share as Share>::LightShare>, DynError>;
 }

--- a/nomos-services/storage/src/api/da/mod.rs
+++ b/nomos-services/storage/src/api/da/mod.rs
@@ -1,8 +1,42 @@
 use std::{collections::HashSet, error::Error};
 
 use async_trait::async_trait;
+use nomos_core::da::blob::Share;
 
 pub mod requests;
+
+pub trait DaConverter<B: StorageDaApi> {
+    type Share: Share;
+    type Error: Error + Send + Sync + 'static;
+
+    fn blob_id_to_storage(
+        blob_id: <Self::Share as Share>::BlobId,
+    ) -> Result<B::BlobId, Self::Error>;
+
+    fn blob_id_from_storage(
+        blob_id: B::BlobId,
+    ) -> Result<<Self::Share as Share>::BlobId, Self::Error>;
+
+    fn share_index_to_storage(
+        share_index: <Self::Share as Share>::ShareIndex,
+    ) -> Result<B::ShareIndex, Self::Error>;
+
+    fn share_index_from_storage(
+        share_index: B::ShareIndex,
+    ) -> Result<<Self::Share as Share>::ShareIndex, Self::Error>;
+    fn share_to_storage(
+        service_share: <Self::Share as Share>::LightShare,
+    ) -> Result<B::Share, Self::Error>;
+    fn share_from_storage(
+        backend_share: B::Share,
+    ) -> Result<<Self::Share as Share>::LightShare, Self::Error>;
+    fn commitments_to_storage(
+        service_commitments: <Self::Share as Share>::SharesCommitments,
+    ) -> Result<B::Commitments, Self::Error>;
+    fn commitments_from_storage(
+        backend_commitments: B::Commitments,
+    ) -> Result<<Self::Share as Share>::SharesCommitments, Self::Error>;
+}
 
 #[async_trait]
 pub trait StorageDaApi {


### PR DESCRIPTION
## 1. What does this PR implement?

Move storage and service types conversion behind `Converter` trait. Previously such conversions were done by separate `From` trait implementations which wasn’t very clean approach.

`Converter` is similar to existing `SerdeOp` but works with new storage abstraction layer. Perhaps in future we don’t need  `SerdeOp` and can remove it.

In this PR it’s done only for DA. If this approach seems good then in future I’ll do the same for chain types(which currently is just `Block` though). 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@andrussal 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 5. Link PR to a specific milestone.
