### PR TITLE
feat: do not add external address to kademlia automatically

### DIFF
--- a/nomos-libp2p/Cargo.toml
+++ b/nomos-libp2p/Cargo.toml
@@ -20,7 +20,6 @@ libp2p = { workspace = true, features = [
 ] }
 multiaddr = "0.18"
 serde = { version = "1.0.166", features = ["derive"] }
-thiserror = "1.0.40"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/nomos-libp2p/src/swarm.rs
+++ b/nomos-libp2p/src/swarm.rs
@@ -71,7 +71,7 @@ impl Swarm {
         let nomos_swarm = {
             let listen_addr = multiaddr(config.host, config.port);
             let mut s = Self { swarm };
-            // We start listening on the provided address, which triggers the Identify flow, which in turn triggers are AutoNAT behaviour.
+            // We start listening on the provided address, which triggers the Identify flow, which in turn triggers our NAT traversal state machine.
             s.start_listening_on(listen_addr.clone())
                 .map_err(|e| format!("Failed to listen on {listen_addr}: {e}"))?;
             Ok::<_, Box<dyn Error>>(s)

--- a/nomos-libp2p/src/swarm.rs
+++ b/nomos-libp2p/src/swarm.rs
@@ -5,6 +5,7 @@
 
 use std::{
     error::Error,
+    io,
     net::Ipv4Addr,
     pin::Pin,
     task::{Context, Poll},
@@ -14,23 +15,14 @@ use std::{
 use libp2p::{
     identity::ed25519,
     swarm::{dial_opts::DialOpts, ConnectionId, DialError, SwarmEvent},
-    Multiaddr, PeerId,
+    Multiaddr, PeerId, TransportError,
 };
-use multiaddr::{multiaddr, Protocol};
+use multiaddr::multiaddr;
 
 use crate::{
     behaviour::{Behaviour, BehaviourEvent},
     SwarmConfig,
 };
-
-#[derive(thiserror::Error, Debug)]
-pub enum SwarmError {
-    #[error("duplicate dialing")]
-    DuplicateDialing,
-
-    #[error("no known peers")]
-    NoKnownPeers,
-}
 
 /// How long to keep a connection alive once it is idling.
 const IDLE_CONN_TIMEOUT: Duration = Duration::from_secs(300);
@@ -59,7 +51,7 @@ impl Swarm {
             ..
         } = config;
 
-        let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
+        let swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
             .with_tokio()
             .with_quic()
             .with_dns()?
@@ -76,23 +68,16 @@ impl Swarm {
             .with_swarm_config(|c| c.with_idle_connection_timeout(IDLE_CONN_TIMEOUT))
             .build();
 
-        let listen_addr = multiaddr(config.host, config.port);
-        swarm.listen_on(listen_addr.clone())?;
+        let nomos_swarm = {
+            let listen_addr = multiaddr(config.host, config.port);
+            let mut s = Self { swarm };
+            // We start listening on the provided address, which triggers the Identify flow, which in turn triggers are AutoNAT behaviour.
+            s.start_listening_on(listen_addr.clone())
+                .map_err(|e| format!("Failed to listen on {listen_addr}: {e}"))?;
+            Ok::<_, Box<dyn Error>>(s)
+        }?;
 
-        // if kademlia is enabled and is not in client mode then it is operating in a
-        // server mode
-        if let Some(kademlia_config) = &kademlia_config {
-            if !kademlia_config.client_mode {
-                // libp2p2-kad server mode is implicitly enabled
-                // by adding external addressess
-                // <https://github.com/libp2p/rust-libp2p/blob/master/protocols/kad/CHANGELOG.md#0440>
-                let external_addr = listen_addr.with(Protocol::P2p(peer_id));
-                swarm.add_external_address(external_addr.clone());
-                tracing::info!("Added external address: {}", external_addr);
-            }
-        }
-
-        Ok(Self { swarm })
+        Ok(nomos_swarm)
     }
 
     /// Initiates a connection attempt to a peer
@@ -103,6 +88,11 @@ impl Swarm {
         tracing::debug!("attempting to dial {peer_addr}. connection_id:{connection_id:?}",);
         self.swarm.dial(opt)?;
         Ok(connection_id)
+    }
+
+    pub fn start_listening_on(&mut self, addr: Multiaddr) -> Result<(), TransportError<io::Error>> {
+        self.swarm.listen_on(addr)?;
+        Ok(())
     }
 
     /// Returns a reference to the underlying [`libp2p::Swarm`]

--- a/nomos-libp2p/src/swarm.rs
+++ b/nomos-libp2p/src/swarm.rs
@@ -71,7 +71,8 @@ impl Swarm {
         let nomos_swarm = {
             let listen_addr = multiaddr(config.host, config.port);
             let mut s = Self { swarm };
-            // We start listening on the provided address, which triggers the Identify flow, which in turn triggers our NAT traversal state machine.
+            // We start listening on the provided address, which triggers the Identify flow,
+            // which in turn triggers our NAT traversal state machine.
             s.start_listening_on(listen_addr.clone())
                 .map_err(|e| format!("Failed to listen on {listen_addr}: {e}"))?;
             Ok::<_, Box<dyn Error>>(s)

--- a/nomos-services/network/src/backends/libp2p/swarm/mod.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm/mod.rs
@@ -286,6 +286,7 @@ mod tests {
     const NODE_COUNT: usize = 10;
 
     #[tokio::test]
+    #[ignore = "We are changing the way confirmed external addresses are added to the Kademlia DHT, hence this test will fail until we complete the integration of the NAT traversal machine."]
     async fn test_kademlia_bootstrap() {
         init_tracing();
 


### PR DESCRIPTION
## 1. What does this PR implement?

With the new NAT traversal integration, we confirm external addresses only after they have been verified by the (under development) black box machine, hence we do not add them anymore to kademlia directly (unless there will be an explicit configuration stating so).

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
