### PR TITLE
fix(ci): Make cache keys independent between runners' OSs.

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Set up Cargo cache
         uses: ./.github/actions/setup-cargo-cache
         with:
-          key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ matrix.os }}
+          key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ join(matrix.os, '_') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build required binaries
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
@@ -205,7 +205,7 @@ jobs:
         if: success() || failure()
         uses: ./.github/actions/update-cargo-cache
         with:
-          key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ matrix.os }}
+          key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ join(matrix.os, '_') }}
       - name: Upload integration tests results
         uses: actions/upload-artifact@6027e3dd177782cd8ab9af838c04fd81a07f1d47 # Version 4.6.2
         if: failure()


### PR DESCRIPTION
## 1. What does this PR implement?
The way `github` does string interpolation made it so that the OS array (e.g. `[self-hosted, macOS]`) was printed as its type (e.g. `Array`), which means different OSs were sharing the same cache.
This PR makes it so the string interpolation for arrays prints the values instead of the type (e.g. `self-hosted_macOS`).

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. Description added.
* [X] 2. Context and links to Specification document(s) added.
* [X] 3. Main contact(s) (developers and specification authors) added
* [X] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 5. Link PR to a specific milestone.
