### PR TITLE
fix: clippy should panic message

### DIFF
--- a/nomos-da/kzgrs-backend/src/encoder.rs
+++ b/nomos-da/kzgrs-backend/src/encoder.rs
@@ -409,7 +409,7 @@ pub mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "polynomial_degree.is_power_of_two()")]
     fn test_encode_zeros() {
         // 837 zeros is not arbitrary, bug discovered on offsite 2025/04/22
         // Encoding only zeroes is not allowed in Nomos DA network.


### PR DESCRIPTION
Fixes:
```
   --> nomos-da/kzgrs-backend/src/encoder.rs:412:5
    |
412 |     #[should_panic]
    |     ^^^^^^^^^^^^^^^ help: consider specifying the expected panic: `#[should_panic(expected = /* panic message */)]`
    
 ```

cc. @danielSanchezQ This is what I added to my PR, so I removed it to a separate tiny PR