### PR TITLE
chore: setup config for rustc lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -106,28 +106,13 @@ rustflags = [
   "-Aclippy::unwrap_in_result",
   "-Aclippy::unwrap_used",
 
-  # Rustc lints
+  # Explicitly allowed Rustc lints
 
-  # Warn-by-default for all rustc lint groups, so new lints generate a warning and need explicit handling
-  "-Wdeprecated-safe",
-  "-Wfuture-incompatible",
-  "-Wkeyword-idents",
-  "-Wlet-underscore",
-  "-Wnonstandard-style",
-  "-Wrefining-impl-trait",
-  "-Wrust-2018-compatibility",
-  "-Wrust-2018-idioms",
-  "-Wrust-2021-compatibility",
-  "-Wrust-2024-compatibility",
-  "-Wunused",
-
-  # Explicitly allowed lints
-
-  # Allow-by-default to warning lints
+  # Rustc lints which are allow-by-default but have been changed to "warn"
   "-Wredundant_imports",
   "-Wredundant_lifetimes",
 
-  # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently and move them to the relative section, or enforce them, and move them to the relative section.
+  # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
   "-Aabsolute_paths_not_starting_with_crate",
   "-Aambiguous_negative_literals",
   "-Aclosure_returning_async_block",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,5 @@
+# DO NOT RE-ORDER LINES IN THIS FILE, AS ORDER MATTERS!
+
 [target.'cfg(target_os = "macos")']
 # when using osx, we need to link against some golang libraries, it did just work with this missing flags
 # from: https://github.com/golang/go/issues/42459
@@ -69,7 +71,7 @@ rustflags = [
   "-Aclippy::use_debug",
   "-Aclippy::wildcard_enum_match_arm",
 
-  # TODO: Address these lints at some point.
+  # TODO: Address these Clippy lints at some point (by deleting the entry, which turns them into warnings).
   "-Aclippy::arithmetic_side_effects",
   "-Aclippy::as_conversions",
   "-Aclippy::as_pointer_underscore",
@@ -103,4 +105,77 @@ rustflags = [
   "-Aclippy::unreachable",
   "-Aclippy::unwrap_in_result",
   "-Aclippy::unwrap_used",
+
+  # Rustc lints
+
+  # Warn-by-default for all rustc lint groups, so new lints generate a warning and need explicit handling
+  "-Wdeprecated-safe",
+  "-Wfuture-incompatible",
+  "-Wkeyword-idents",
+  "-Wlet-underscore",
+  "-Wnonstandard-style",
+  "-Wrefining-impl-trait",
+  "-Wrust-2018-compatibility",
+  "-Wrust-2018-idioms",
+  "-Wrust-2021-compatibility",
+  "-Wrust-2024-compatibility",
+  "-Wunused",
+
+  # Explicitly allowed lints
+
+  # Allow-by-default to warning lints
+  "-Wredundant_imports",
+  "-Wredundant_lifetimes",
+
+  # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently and move them to the relative section, or enforce them, and move them to the relative section.
+  "-Aabsolute_paths_not_starting_with_crate",
+  "-Aambiguous_negative_literals",
+  "-Aclosure_returning_async_block",
+  "-Adeprecated_safe_2024",
+  "-Aderef_into_dyn_supertrait",
+  "-Aedition_2024_expr_fragment_specifier",
+  "-Aelided_lifetimes_in_paths",
+  "-Aexplicit_outlives_requirements",
+  "-Affi_unwind_calls",
+  "-Aif_let_rescope",
+  "-Aimpl_trait_overcaptures",
+  "-Aimpl_trait_redundant_captures",
+  "-Akeyword-idents",
+  "-Akeyword_idents_2018",
+  "-Akeyword_idents_2024",
+  "-Alet_underscore_drop",
+  "-Alinker_messages",
+  "-Amacro_use_extern_crate",
+  "-Ameta_variable_misuse",
+  "-Amissing_copy_implementations",
+  "-Amissing_debug_implementations",
+  "-Amissing_docs",
+  "-Amissing_unsafe_on_extern",
+  "-Anon_ascii_idents",
+  "-Arust_2021_incompatible_closure_captures",
+  "-Arust_2021_incompatible_or_patterns",
+  "-Arust_2021_prefixes_incompatible_syntax",
+  "-Arust_2021_prelude_collisions",
+  "-Arust_2024_guarded_string_incompatible_syntax",
+  "-Arust_2024_incompatible_pat",
+  "-Arust_2024_prelude_collisions",
+  "-Asingle_use_lifetimes",
+  "-Atail_expr_drop_order",
+  "-Atrivial_casts",
+  "-Atrivial_numeric_casts",
+  "-Aunit_bindings",
+  "-Aunnameable_types",
+  "-Aunreachable_pub",
+  "-Aunsafe_attr_outside_unsafe",
+  "-Aunsafe_code",
+  "-Aunsafe_op_in_unsafe_fn",
+  "-Aunstable_features",
+  "-Aunused_crate_dependencies",
+  "-Aunused_extern_crates",
+  "-Aunused_import_braces",
+  "-Aunused_lifetimes",
+  "-Aunused_macro_rules",
+  "-Aunused_qualifications",
+  "-Aunused_results",
+  "-Avariant_size_differences"
 ]

--- a/ledger/nomos-ledger/src/lib.rs
+++ b/ledger/nomos-ledger/src/lib.rs
@@ -458,12 +458,11 @@ pub mod tests {
 
     use blake2::Digest as _;
     use cl::{note::NoteWitness as Note, NullifierSecret};
-    use cryptarchia_engine::{EpochConfig, Slot};
+    use cryptarchia_engine::EpochConfig;
     use rand::thread_rng;
-    use rpds::HashTrieSet;
 
     use super::*;
-    use crate::{crypto::Blake2b, leader_proof::LeaderProof, Config, LedgerError};
+    use crate::leader_proof::LeaderProof;
 
     type HeaderId = [u8; 32];
 

--- a/nomos-da/network/core/src/maintenance/balancer.rs
+++ b/nomos-da/network/core/src/maintenance/balancer.rs
@@ -183,15 +183,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::{HashSet, VecDeque},
-        time::Duration,
-    };
+    use std::{collections::HashSet, time::Duration};
 
-    use libp2p::{
-        swarm::{Swarm, SwarmEvent},
-        PeerId,
-    };
+    use libp2p::swarm::{Swarm, SwarmEvent};
     use libp2p_swarm_test::SwarmExt as _;
     use tokio::time::timeout;
 

--- a/nomos-da/network/core/src/swarm/common/balancer.rs
+++ b/nomos-da/network/core/src/swarm/common/balancer.rs
@@ -180,13 +180,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashSet,
-        task::{Context, Poll},
-    };
-
     use futures::stream;
-    use libp2p::PeerId;
     use tokio_stream::StreamExt as _;
 
     use super::*;

--- a/nomos-da/network/core/src/swarm/common/monitor.rs
+++ b/nomos-da/network/core/src/swarm/common/monitor.rs
@@ -372,9 +372,6 @@ fn compute_failure_rate(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use libp2p::PeerId;
     use subnetworks_assignations::versions::v1::FillFromNodeList;
 
     use super::*;

--- a/nomos-sdp/src/ledger.rs
+++ b/nomos-sdp/src/ledger.rs
@@ -302,11 +302,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashMap,
-        marker::PhantomData,
-        sync::{Arc, Mutex},
-    };
+    use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
     use multiaddr::multiaddr;
@@ -671,13 +667,10 @@ mod tests {
             (0, vec![(declaration_a, true), (declaration_b, true)]),
             (10, vec![(BOp::Act(pid, d1, St::BlendNetwork), true)]),
             (20, vec![(BOp::Act(pid, d2, St::DataAvailability), true)]),
-            (
-                30,
-                vec![
-                    (BOp::Wit(pid, d1, St::BlendNetwork), true),
-                    (BOp::Wit(pid, d2, St::DataAvailability), true),
-                ],
-            ),
+            (30, vec![
+                (BOp::Wit(pid, d1, St::BlendNetwork), true),
+                (BOp::Wit(pid, d2, St::DataAvailability), true),
+            ]),
         ]
         .into();
 
@@ -698,34 +691,28 @@ mod tests {
         assert_eq!(providers.len(), 2);
 
         let provider = providers.get(&d1).unwrap();
-        assert_eq!(
-            provider,
-            &DeclarationInfo {
-                provider_id: pid,
-                id: d1,
-                created: 0,
-                active: Some(10),
-                withdrawn: Some(30),
-                service: ServiceType::BlendNetwork,
-                locators: locators.clone(),
-                reward_address: reward_addr,
-            }
-        );
+        assert_eq!(provider, &DeclarationInfo {
+            provider_id: pid,
+            id: d1,
+            created: 0,
+            active: Some(10),
+            withdrawn: Some(30),
+            service: ServiceType::BlendNetwork,
+            locators: locators.clone(),
+            reward_address: reward_addr,
+        });
 
         let provider = providers.get(&d2).unwrap();
-        assert_eq!(
-            provider,
-            &DeclarationInfo {
-                provider_id: pid,
-                id: d2,
-                created: 0,
-                active: Some(20),
-                withdrawn: Some(30),
-                service: ServiceType::DataAvailability,
-                locators,
-                reward_address: reward_addr,
-            }
-        );
+        assert_eq!(provider, &DeclarationInfo {
+            provider_id: pid,
+            id: d2,
+            created: 0,
+            active: Some(20),
+            withdrawn: Some(30),
+            service: ServiceType::DataAvailability,
+            locators,
+            reward_address: reward_addr,
+        });
     }
 
     #[tokio::test]
@@ -745,15 +732,12 @@ mod tests {
             (0, vec![(declaration_a, true), (declaration_b, true)]),
             (10, vec![(BOp::Act(p1, d1, St::BlendNetwork), true)]),
             (20, vec![(BOp::Act(p2, d2, St::DataAvailability), true)]),
-            (
-                30,
-                vec![
-                    // Withdrawing service that pid2 declared.
-                    (BOp::Wit(p1, d2, St::BlendNetwork), false),
-                    // Withdrawing service that pid1 declared.
-                    (BOp::Wit(p2, d1, St::DataAvailability), false),
-                ],
-            ),
+            (30, vec![
+                // Withdrawing service that pid2 declared.
+                (BOp::Wit(p1, d2, St::BlendNetwork), false),
+                // Withdrawing service that pid1 declared.
+                (BOp::Wit(p2, d1, St::DataAvailability), false),
+            ]),
         ]
         .into();
         let blocks = gen_blocks(blocks);
@@ -773,33 +757,27 @@ mod tests {
         assert_eq!(providers.len(), 2);
 
         let info1 = providers.get(&d1).unwrap();
-        assert_eq!(
-            info1,
-            &DeclarationInfo {
-                provider_id: p1,
-                id: d1,
-                created: 0,
-                active: Some(10),
-                withdrawn: None,
-                service: ServiceType::BlendNetwork,
-                locators: locators.clone(),
-                reward_address: reward_addr,
-            }
-        );
+        assert_eq!(info1, &DeclarationInfo {
+            provider_id: p1,
+            id: d1,
+            created: 0,
+            active: Some(10),
+            withdrawn: None,
+            service: ServiceType::BlendNetwork,
+            locators: locators.clone(),
+            reward_address: reward_addr,
+        });
 
         let info2 = providers.get(&d2).unwrap();
-        assert_eq!(
-            info2,
-            &DeclarationInfo {
-                provider_id: p2,
-                id: d2,
-                created: 0,
-                active: Some(20),
-                withdrawn: None,
-                service: ServiceType::DataAvailability,
-                locators,
-                reward_address: reward_addr,
-            }
-        );
+        assert_eq!(info2, &DeclarationInfo {
+            provider_id: p2,
+            id: d2,
+            created: 0,
+            active: Some(20),
+            withdrawn: None,
+            service: ServiceType::DataAvailability,
+            locators,
+            reward_address: reward_addr,
+        });
     }
 }

--- a/nomos-sdp/src/ledger.rs
+++ b/nomos-sdp/src/ledger.rs
@@ -667,10 +667,13 @@ mod tests {
             (0, vec![(declaration_a, true), (declaration_b, true)]),
             (10, vec![(BOp::Act(pid, d1, St::BlendNetwork), true)]),
             (20, vec![(BOp::Act(pid, d2, St::DataAvailability), true)]),
-            (30, vec![
-                (BOp::Wit(pid, d1, St::BlendNetwork), true),
-                (BOp::Wit(pid, d2, St::DataAvailability), true),
-            ]),
+            (
+                30,
+                vec![
+                    (BOp::Wit(pid, d1, St::BlendNetwork), true),
+                    (BOp::Wit(pid, d2, St::DataAvailability), true),
+                ],
+            ),
         ]
         .into();
 
@@ -691,28 +694,34 @@ mod tests {
         assert_eq!(providers.len(), 2);
 
         let provider = providers.get(&d1).unwrap();
-        assert_eq!(provider, &DeclarationInfo {
-            provider_id: pid,
-            id: d1,
-            created: 0,
-            active: Some(10),
-            withdrawn: Some(30),
-            service: ServiceType::BlendNetwork,
-            locators: locators.clone(),
-            reward_address: reward_addr,
-        });
+        assert_eq!(
+            provider,
+            &DeclarationInfo {
+                provider_id: pid,
+                id: d1,
+                created: 0,
+                active: Some(10),
+                withdrawn: Some(30),
+                service: ServiceType::BlendNetwork,
+                locators: locators.clone(),
+                reward_address: reward_addr,
+            }
+        );
 
         let provider = providers.get(&d2).unwrap();
-        assert_eq!(provider, &DeclarationInfo {
-            provider_id: pid,
-            id: d2,
-            created: 0,
-            active: Some(20),
-            withdrawn: Some(30),
-            service: ServiceType::DataAvailability,
-            locators,
-            reward_address: reward_addr,
-        });
+        assert_eq!(
+            provider,
+            &DeclarationInfo {
+                provider_id: pid,
+                id: d2,
+                created: 0,
+                active: Some(20),
+                withdrawn: Some(30),
+                service: ServiceType::DataAvailability,
+                locators,
+                reward_address: reward_addr,
+            }
+        );
     }
 
     #[tokio::test]
@@ -732,12 +741,15 @@ mod tests {
             (0, vec![(declaration_a, true), (declaration_b, true)]),
             (10, vec![(BOp::Act(p1, d1, St::BlendNetwork), true)]),
             (20, vec![(BOp::Act(p2, d2, St::DataAvailability), true)]),
-            (30, vec![
-                // Withdrawing service that pid2 declared.
-                (BOp::Wit(p1, d2, St::BlendNetwork), false),
-                // Withdrawing service that pid1 declared.
-                (BOp::Wit(p2, d1, St::DataAvailability), false),
-            ]),
+            (
+                30,
+                vec![
+                    // Withdrawing service that pid2 declared.
+                    (BOp::Wit(p1, d2, St::BlendNetwork), false),
+                    // Withdrawing service that pid1 declared.
+                    (BOp::Wit(p2, d1, St::DataAvailability), false),
+                ],
+            ),
         ]
         .into();
         let blocks = gen_blocks(blocks);
@@ -757,27 +769,33 @@ mod tests {
         assert_eq!(providers.len(), 2);
 
         let info1 = providers.get(&d1).unwrap();
-        assert_eq!(info1, &DeclarationInfo {
-            provider_id: p1,
-            id: d1,
-            created: 0,
-            active: Some(10),
-            withdrawn: None,
-            service: ServiceType::BlendNetwork,
-            locators: locators.clone(),
-            reward_address: reward_addr,
-        });
+        assert_eq!(
+            info1,
+            &DeclarationInfo {
+                provider_id: p1,
+                id: d1,
+                created: 0,
+                active: Some(10),
+                withdrawn: None,
+                service: ServiceType::BlendNetwork,
+                locators: locators.clone(),
+                reward_address: reward_addr,
+            }
+        );
 
         let info2 = providers.get(&d2).unwrap();
-        assert_eq!(info2, &DeclarationInfo {
-            provider_id: p2,
-            id: d2,
-            created: 0,
-            active: Some(20),
-            withdrawn: None,
-            service: ServiceType::DataAvailability,
-            locators,
-            reward_address: reward_addr,
-        });
+        assert_eq!(
+            info2,
+            &DeclarationInfo {
+                provider_id: p2,
+                id: d2,
+                created: 0,
+                active: Some(20),
+                withdrawn: None,
+                service: ServiceType::DataAvailability,
+                locators,
+                reward_address: reward_addr,
+            }
+        );
     }
 }

--- a/nomos-services/data-availability/sampling/src/backend/kzgrs.rs
+++ b/nomos-services/data-availability/sampling/src/backend/kzgrs.rs
@@ -5,7 +5,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use hex;
 use kzgrs_backend::common::{
     share::{DaShare, DaSharesCommitments},
     ShareIndex,
@@ -167,7 +166,7 @@ mod test {
     use kzgrs::Proof;
     use kzgrs_backend::common::{share::DaShare, Column};
     use nomos_core::da::BlobId;
-    use rand::{prelude::*, rngs::StdRng};
+    use rand::prelude::*;
 
     use crate::backend::kzgrs::{
         DaSamplingServiceBackend as _, KzgrsSamplingBackend, KzgrsSamplingBackendSettings,

--- a/nomos-services/key-management-system/src/backend/preload.rs
+++ b/nomos-services/key-management-system/src/backend/preload.rs
@@ -119,8 +119,6 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use rand::rngs::OsRng;
 
     use super::*;

--- a/nomos-services/time/src/backends/ntp/testutils.rs
+++ b/nomos-services/time/src/backends/ntp/testutils.rs
@@ -183,13 +183,9 @@ impl<TimestampGenerator: TimestampGeneratorTrait + Send + Sync> FakeNTPServer<Ti
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr},
-        time::Duration,
-    };
+    use std::net::{IpAddr, Ipv4Addr};
 
     use log::trace;
-    use time::OffsetDateTime;
 
     use super::*;
     use crate::backends::ntp::async_client::{AsyncNTPClient, NTPClientSettings};

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,6 +8,7 @@
 # Also, update the version of the nightly toolchain to the latest nightly of the new version specified in the following places:
 # * workflows/code-check.yml (fmt job)
 # * .pre-commit-config.yml (fmt hook)
+# Then, if there is any new allow-by-default rustc lint introduced/stabilized, and if the new lint is to be enforced, add it to the respective entry in our `config.toml`.
 channel = "1.87.0"
 # Even if clippy should be included in the default profile, in some cases it is not installed. So we force it with an explicit declaration.
 components = ["clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,7 +8,7 @@
 # Also, update the version of the nightly toolchain to the latest nightly of the new version specified in the following places:
 # * workflows/code-check.yml (fmt job)
 # * .pre-commit-config.yml (fmt hook)
-# Then, if there is any new allow-by-default rustc lint introduced/stabilized, and if the new lint is to be enforced, add it to the respective entry in our `config.toml`.
+# Then, if there is any new allow-by-default rustc lint introduced/stabilized, add it to the respective entry in our `config.toml`.
 channel = "1.87.0"
 # Even if clippy should be included in the default profile, in some cases it is not installed. So we force it with an explicit declaration.
 components = ["clippy"]


### PR DESCRIPTION
## 1. What does this PR implement?

There are a bunch of rustc lints which are allow-by-default.  The list is presented [here](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html). This PR sets up our `.cargo/config.toml` to list them all explicitly, so  that future PRs can tackle them in batches. As for this PR, we enforce `redundant_imports` (which triggered some warnings) and `redundant_lifetimes` (which did not trigger any warnings).

Unfortunately there is no exhaustive list of groups that contains all allow-by-default lints, hence we need to manually add new lints whenever we upgrade our Rust version, in case new allow-by-default lints have been introduced or stabilised.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
