### PR TITLE
fix(membership): assert block number and latest block number in update

### DIFF
--- a/nomos-services/membership/Cargo.toml
+++ b/nomos-services/membership/Cargo.toml
@@ -12,6 +12,7 @@ nomos-sdp      = { workspace = true }
 nomos-sdp-core = { workspace = true }
 overwatch      = { workspace = true }
 serde          = { version = "1.0", features = ["derive"] }
+thiserror      = "1"
 tokio          = { version = "1", features = ["macros", "sync"] }
 tokio-stream   = "0.1"
 tracing        = { version = "0.1", features = ["attributes"] }

--- a/nomos-services/membership/src/backends/mock.rs
+++ b/nomos-services/membership/src/backends/mock.rs
@@ -70,6 +70,12 @@ impl MembershipBackend for MockMembershipBackend {
     ) -> Result<HashMap<ServiceType, MembershipProviders>, MembershipBackendError> {
         let block_number = update.block_number;
 
+        if block_number <= self.latest_block_number {
+            return Err(MembershipBackendError::Other(
+                "Block number is not greater than the latest block number".into(),
+            ));
+        }
+
         let mut latest_entry = self
             .membership
             .get(&self.latest_block_number)

--- a/nomos-services/membership/src/backends/mock.rs
+++ b/nomos-services/membership/src/backends/mock.rs
@@ -71,9 +71,7 @@ impl MembershipBackend for MockMembershipBackend {
         let block_number = update.block_number;
 
         if block_number <= self.latest_block_number {
-            return Err(MembershipBackendError::Other(
-                "Block number is not greater than the latest block number".into(),
-            ));
+            return Err(MembershipBackendError::BlockFromPast);
         }
 
         let mut latest_entry = self

--- a/nomos-services/membership/src/backends/mod.rs
+++ b/nomos-services/membership/src/backends/mod.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use nomos_core::block::BlockNumber;
-use nomos_sdp::backends::SdpBackendError;
 use nomos_sdp_core::{FinalizedBlockEvent, ServiceType};
 use overwatch::DynError;
+use thiserror::Error;
 
 use crate::MembershipProviders;
 
@@ -18,11 +18,13 @@ pub struct Settings {
     historical_block_delta: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum MembershipBackendError {
-    Other(DynError),
-    Sdp(SdpBackendError),
-    MockBackendError(DynError),
+    #[error("Other error: {0}")]
+    Other(#[from] DynError),
+
+    #[error("The block received is not greater than the last known block")]
+    BlockFromPast,
 }
 
 #[async_trait]


### PR DESCRIPTION
This PR is a small fix in membership service mock backed. The update method needs to assert that the new finalized block is > then current latest
