### PR TITLE
chore: process rustc `unused*` lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,9 +215,17 @@ unwrap_used                 = { level = "allow" }
 
 # Explicitly allowed lints
 
+unused_crate_dependencies = { level = "allow" } # Too many false positives especially around benchmarking and binaries, which do not have their own `dependencies` section yet. Plus, we have cargo-machete checking unused deps.
+unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
+
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports   = { level = "warn" }
-redundant_lifetimes = { level = "warn" }
+redundant_imports     = { level = "warn" }
+redundant_lifetimes   = { level = "warn" }
+unused_extern_crates  = { level = "warn" }
+unused_import_braces  = { level = "warn" }
+unused_lifetimes      = { level = "warn" }
+unused_macro_rules    = { level = "warn" }
+unused_qualifications = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
 # When doing so, please update the same table for all crates that are not part of the workspace.
@@ -263,13 +271,6 @@ unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 unsafe_op_in_unsafe_fn                       = { level = "allow" }
 unstable_features                            = { level = "allow" }
-unused_crate_dependencies                    = { level = "allow" }
-unused_extern_crates                         = { level = "allow" }
-unused_import_braces                         = { level = "allow" }
-unused_lifetimes                             = { level = "allow" }
-unused_macro_rules                           = { level = "allow" }
-unused_qualifications                        = { level = "allow" }
-unused_results                               = { level = "allow" }
 variant_size_differences                     = { level = "allow" }
 
 [workspace.package]

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -21,19 +21,19 @@ pub struct Boostrapping;
 #[derive(Clone, Debug, Copy)]
 pub struct Online;
 
-pub trait CryptarchiaState: Copy + std::fmt::Debug {
+pub trait CryptarchiaState: Copy + Debug {
     fn fork_choice<Id>(cryptarchia: &Cryptarchia<Id, Self>) -> Branch<Id>
     where
-        Id: Eq + std::hash::Hash + Copy;
+        Id: Eq + Hash + Copy;
     fn lib<Id>(cryptarchia: &Cryptarchia<Id, Self>) -> Id
     where
-        Id: Eq + std::hash::Hash + Copy;
+        Id: Eq + Hash + Copy;
 }
 
 impl CryptarchiaState for Boostrapping {
     fn fork_choice<Id>(cryptarchia: &Cryptarchia<Id, Self>) -> Branch<Id>
     where
-        Id: Eq + std::hash::Hash + Copy,
+        Id: Eq + Hash + Copy,
     {
         let k = cryptarchia.config.security_param.get().into();
         let s = cryptarchia.config.s();
@@ -42,7 +42,7 @@ impl CryptarchiaState for Boostrapping {
 
     fn lib<Id>(cryptarchia: &Cryptarchia<Id, Self>) -> Id
     where
-        Id: Eq + std::hash::Hash + Copy,
+        Id: Eq + Hash + Copy,
     {
         cryptarchia.branches.lib
     }
@@ -51,7 +51,7 @@ impl CryptarchiaState for Boostrapping {
 impl CryptarchiaState for Online {
     fn fork_choice<Id>(cryptarchia: &Cryptarchia<Id, Self>) -> Branch<Id>
     where
-        Id: Eq + std::hash::Hash + Copy,
+        Id: Eq + Hash + Copy,
     {
         let k = cryptarchia.config.security_param.get().into();
         maxvalid_mc(cryptarchia.local_chain, &cryptarchia.branches, k)
@@ -59,7 +59,7 @@ impl CryptarchiaState for Online {
 
     fn lib<Id>(cryptarchia: &Cryptarchia<Id, Self>) -> Id
     where
-        Id: Eq + std::hash::Hash + Copy,
+        Id: Eq + Hash + Copy,
     {
         cryptarchia
             .branches
@@ -77,7 +77,7 @@ impl CryptarchiaState for Online {
 // happened we will inspect for chain density
 fn maxvalid_bg<Id>(local_chain: Branch<Id>, branches: &Branches<Id>, k: u64, s: u64) -> Branch<Id>
 where
-    Id: Eq + std::hash::Hash + Copy,
+    Id: Eq + Hash + Copy,
 {
     let mut cmax = local_chain;
     let forks = branches.branches();
@@ -107,7 +107,7 @@ where
 // paper k defines the forking depth of chain we can accept
 fn maxvalid_mc<Id>(local_chain: Branch<Id>, branches: &Branches<Id>, k: u64) -> Branch<Id>
 where
-    Id: Eq + std::hash::Hash + Copy,
+    Id: Eq + Hash + Copy,
 {
     let mut cmax = local_chain;
     let forks = branches.branches();
@@ -186,7 +186,7 @@ impl<Id: Copy> Branch<Id> {
 
 impl<Id> Branches<Id>
 where
-    Id: Eq + std::hash::Hash + Copy,
+    Id: Eq + Hash + Copy,
 {
     pub fn from_lib(lib: Id) -> Self {
         let mut branches = HashMap::new();
@@ -356,7 +356,7 @@ pub struct ForkDivergenceInfo<Id> {
 
 impl<Id, State> Cryptarchia<Id, State>
 where
-    Id: Eq + std::hash::Hash + Copy + Debug,
+    Id: Eq + Hash + Copy + Debug,
     State: CryptarchiaState + Copy,
 {
     pub fn from_lib(id: Id, config: Config) -> Self {
@@ -498,7 +498,7 @@ where
 
 impl<Id> Cryptarchia<Id, Boostrapping>
 where
-    Id: Eq + std::hash::Hash + Copy + Debug,
+    Id: Eq + Hash + Copy + Debug,
 {
     /// Signal transitioning to the online state.
     pub fn online(self) -> Cryptarchia<Id, Online> {

--- a/nodes/nomos-executor/executor/src/api/backend.rs
+++ b/nodes/nomos-executor/executor/src/api/backend.rs
@@ -255,8 +255,8 @@ where
         + Send
         + Sync
         + 'static,
-    <Tx as nomos_core::tx::Transaction>::Hash:
-        Serialize + for<'de> Deserialize<'de> + std::cmp::Ord + Debug + Send + Sync + 'static,
+    <Tx as Transaction>::Hash:
+        Serialize + for<'de> Deserialize<'de> + Ord + Debug + Send + Sync + 'static,
     DaStorageSerializer: StorageSerde + Send + Sync + 'static,
     <DaStorageSerializer as StorageSerde>::Error: Send + Sync,
     DaStorageConverter: da::DaConverter<DaStorageBackend<DaStorageSerializer>, Share = DaShare>

--- a/nodes/nomos-executor/http-client/src/lib.rs
+++ b/nodes/nomos-executor/http-client/src/lib.rs
@@ -63,8 +63,8 @@ impl ExecutorHttpClient {
     where
         C: DeserializeOwned + Send + Sync,
         S: Share + DeserializeOwned + Send + Sync,
-        <S as Share>::BlobId: serde::Serialize + Send + Sync,
-        <S as Share>::ShareIndex: serde::Serialize + Send + Sync,
+        <S as Share>::BlobId: Serialize + Send + Sync,
+        <S as Share>::ShareIndex: Serialize + Send + Sync,
     {
         self.client
             .get_share::<S, C>(base_url, blob_id, share_idx)
@@ -81,8 +81,8 @@ impl ExecutorHttpClient {
     ) -> Result<impl Stream<Item = B::LightShare>, Error>
     where
         B: Share,
-        <B as Share>::BlobId: serde::Serialize + Send + Sync,
-        <B as Share>::ShareIndex: serde::Serialize + DeserializeOwned + Eq + Hash + Send + Sync,
+        <B as Share>::BlobId: Serialize + Send + Sync,
+        <B as Share>::ShareIndex: Serialize + DeserializeOwned + Eq + Hash + Send + Sync,
         <B as Share>::LightShare: DeserializeOwned + Send + Sync,
     {
         self.client

--- a/nodes/nomos-node/http-client/src/lib.rs
+++ b/nodes/nomos-node/http-client/src/lib.rs
@@ -98,7 +98,7 @@ impl CommonHttpClient {
     where
         S: Share,
         S::SharesCommitments: DeserializeOwned + Send + Sync,
-        <S as Share>::BlobId: serde::Serialize + Send + Sync,
+        <S as Share>::BlobId: Serialize + Send + Sync,
     {
         let request: DASharesCommitmentsRequest<S> = DASharesCommitmentsRequest { blob_id };
         let path = DA_GET_SHARES_COMMITMENTS.trim_start_matches('/');
@@ -116,8 +116,8 @@ impl CommonHttpClient {
     where
         C: DeserializeOwned + Send + Sync,
         S: Share + DeserializeOwned + Send + Sync,
-        <S as Share>::BlobId: serde::Serialize + Send + Sync,
-        <S as Share>::ShareIndex: serde::Serialize + Send + Sync,
+        <S as Share>::BlobId: Serialize + Send + Sync,
+        <S as Share>::ShareIndex: Serialize + Send + Sync,
     {
         let request: DaSamplingRequest<S> = DaSamplingRequest { blob_id, share_idx };
         let path = DA_GET_LIGHT_SHARE.trim_start_matches('/');
@@ -135,8 +135,8 @@ impl CommonHttpClient {
     ) -> Result<impl Stream<Item = B::LightShare>, Error>
     where
         B: Share,
-        <B as Share>::BlobId: serde::Serialize + Send + Sync,
-        <B as Share>::ShareIndex: serde::Serialize + DeserializeOwned + Eq + Hash + Send + Sync,
+        <B as Share>::BlobId: Serialize + Send + Sync,
+        <B as Share>::ShareIndex: Serialize + DeserializeOwned + Eq + Hash + Send + Sync,
         <B as Share>::LightShare: DeserializeOwned + Send + Sync,
     {
         let request: GetSharesRequest<B> = GetSharesRequest {

--- a/nodes/nomos-node/node/src/api/backend.rs
+++ b/nodes/nomos-node/node/src/api/backend.rs
@@ -224,8 +224,8 @@ where
         + Send
         + Sync
         + 'static,
-    <Tx as nomos_core::tx::Transaction>::Hash:
-        Serialize + for<'de> Deserialize<'de> + std::cmp::Ord + Debug + Send + Sync + 'static,
+    <Tx as Transaction>::Hash:
+        Serialize + for<'de> Deserialize<'de> + Ord + Debug + Send + Sync + 'static,
     DaStorageSerializer: StorageSerde + Send + Sync + 'static,
     <DaStorageSerializer as StorageSerde>::Error: Send + Sync,
     SamplingRng: SeedableRng + RngCore + Send + 'static,

--- a/nodes/nomos-node/node/src/api/handlers.rs
+++ b/nodes/nomos-node/node/src/api/handlers.rs
@@ -87,8 +87,8 @@ where
         + Send
         + Sync
         + 'static,
-    <T as nomos_core::tx::Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    <T as Transaction>::Hash:
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     RuntimeServiceId:
         Debug + Sync + Display + 'static + AsServiceId<ClMempoolService<T, RuntimeServiceId>>,
 {
@@ -109,8 +109,8 @@ pub async fn cl_status<T, RuntimeServiceId>(
 ) -> Response
 where
     T: Transaction + Clone + Debug + Hash + Serialize + DeserializeOwned + Send + Sync + 'static,
-    <T as nomos_core::tx::Transaction>::Hash:
-        Serialize + DeserializeOwned + std::cmp::Ord + Debug + Send + Sync + 'static,
+    <T as Transaction>::Hash:
+        Serialize + DeserializeOwned + Ord + Debug + Send + Sync + 'static,
     RuntimeServiceId:
         Debug + Sync + Display + 'static + AsServiceId<ClMempoolService<T, RuntimeServiceId>>,
 {
@@ -159,7 +159,7 @@ where
         + Sync
         + 'static,
     <Tx as Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     SS: StorageSerde + Send + Sync + 'static,
     SamplingRng: SeedableRng + RngCore,
     SamplingBackend: DaSamplingServiceBackend<SamplingRng, BlobId = BlobId> + Send,
@@ -169,7 +169,7 @@ where
     SamplingNetworkAdapter: nomos_da_sampling::network::NetworkAdapter<RuntimeServiceId>,
     SamplingStorage: nomos_da_sampling::storage::DaStorageAdapter<RuntimeServiceId>,
     DaVerifierStorage: nomos_da_verifier::storage::DaStorageAdapter<RuntimeServiceId>,
-    DaVerifierBackend: nomos_da_verifier::backend::VerifierBackend + Send + 'static,
+    DaVerifierBackend: VerifierBackend + Send + 'static,
     DaVerifierBackend::Settings: Clone,
     DaVerifierNetwork: nomos_da_verifier::network::NetworkAdapter<RuntimeServiceId>,
     DaVerifierNetwork::Settings: Clone,
@@ -253,7 +253,7 @@ where
         + Sync
         + 'static,
     <Tx as Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     SS: StorageSerde + Send + Sync + 'static,
     SamplingRng: SeedableRng + RngCore,
     SamplingBackend: DaSamplingServiceBackend<SamplingRng, BlobId = BlobId> + Send,
@@ -263,7 +263,7 @@ where
     SamplingNetworkAdapter: nomos_da_sampling::network::NetworkAdapter<RuntimeServiceId>,
     SamplingStorage: nomos_da_sampling::storage::DaStorageAdapter<RuntimeServiceId>,
     DaVerifierStorage: nomos_da_verifier::storage::DaStorageAdapter<RuntimeServiceId>,
-    DaVerifierBackend: nomos_da_verifier::backend::VerifierBackend + Send + 'static,
+    DaVerifierBackend: VerifierBackend + Send + 'static,
     DaVerifierBackend::Settings: Clone,
     DaVerifierNetwork: nomos_da_verifier::network::NetworkAdapter<RuntimeServiceId>,
     DaVerifierNetwork::Settings: Clone,
@@ -393,7 +393,7 @@ where
         + Sync
         + 'static,
     <Tx as Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     C: DispersedBlobInfo<BlobId = [u8; 32]>
         + Clone
         + Debug
@@ -430,7 +430,7 @@ where
     SamplingNetworkAdapter: nomos_da_sampling::network::NetworkAdapter<RuntimeServiceId>,
     SamplingStorage: nomos_da_sampling::storage::DaStorageAdapter<RuntimeServiceId>,
     DaVerifierStorage: nomos_da_verifier::storage::DaStorageAdapter<RuntimeServiceId>,
-    DaVerifierBackend: nomos_da_verifier::backend::VerifierBackend + Send + 'static,
+    DaVerifierBackend: VerifierBackend + Send + 'static,
     DaVerifierBackend::Settings: Clone,
     DaVerifierNetwork: nomos_da_verifier::network::NetworkAdapter<RuntimeServiceId>,
     DaVerifierNetwork::Settings: Clone,
@@ -600,7 +600,7 @@ pub async fn block<S, HttpStorageAdapter, Tx, RuntimeServiceId>(
     Json(id): Json<HeaderId>,
 ) -> Response
 where
-    Tx: serde::Serialize + DeserializeOwned + Clone + Eq + Hash,
+    Tx: Serialize + DeserializeOwned + Clone + Eq + Hash,
     S: StorageSerde + Send + Sync + 'static,
     HttpStorageAdapter: storage::StorageAdapter<S, RuntimeServiceId> + Send + Sync + 'static,
     <S as StorageSerde>::Error: Send + Sync,
@@ -636,7 +636,7 @@ where
     DaShare: Share,
     <DaShare as Share>::BlobId: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     <DaShare as Share>::SharesCommitments:
-        serde::Serialize + DeserializeOwned + Send + Sync + 'static,
+        Serialize + DeserializeOwned + Send + Sync + 'static,
     StorageOp: StorageSerde + Send + Sync + 'static,
     <StorageOp as StorageSerde>::Error: Send + Sync,
     DaStorageConverter:
@@ -723,7 +723,7 @@ pub async fn da_get_shares<
 where
     DaShare: Share + 'static,
     <DaShare as Share>::BlobId: Clone + Send + Sync + 'static,
-    <DaShare as Share>::ShareIndex: serde::Serialize + DeserializeOwned + Send + Sync + Eq + Hash,
+    <DaShare as Share>::ShareIndex: Serialize + DeserializeOwned + Send + Sync + Eq + Hash,
     <DaShare as Share>::LightShare: LightShare<ShareIndex = <DaShare as Share>::ShareIndex>
         + Serialize
         + DeserializeOwned
@@ -831,7 +831,7 @@ pub async fn add_tx<Tx, RuntimeServiceId>(
 where
     Tx: Transaction + Clone + Debug + Hash + Serialize + DeserializeOwned + Send + Sync + 'static,
     <Tx as Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     RuntimeServiceId: Debug
         + Sync
         + Display
@@ -886,7 +886,7 @@ where
         + Send
         + Sync
         + 'static,
-    <B as DispersedBlobInfo>::BlobId: std::cmp::Ord
+    <B as DispersedBlobInfo>::BlobId: Ord
         + Clone
         + Debug
         + Hash
@@ -905,7 +905,7 @@ where
     SamplingRng: SeedableRng + RngCore + Send + 'static,
     SamplingStorage: nomos_da_sampling::storage::DaStorageAdapter<RuntimeServiceId>,
     DaVerifierStorage: nomos_da_verifier::storage::DaStorageAdapter<RuntimeServiceId>,
-    DaVerifierBackend: nomos_da_verifier::backend::VerifierBackend + Send + 'static,
+    DaVerifierBackend: VerifierBackend + Send + 'static,
     DaVerifierBackend::Settings: Clone,
     DaVerifierNetwork: nomos_da_verifier::network::NetworkAdapter<RuntimeServiceId>,
     DaVerifierNetwork::Settings: Clone,

--- a/nodes/nomos-node/node/src/api/handlers.rs
+++ b/nodes/nomos-node/node/src/api/handlers.rs
@@ -109,8 +109,7 @@ pub async fn cl_status<T, RuntimeServiceId>(
 ) -> Response
 where
     T: Transaction + Clone + Debug + Hash + Serialize + DeserializeOwned + Send + Sync + 'static,
-    <T as Transaction>::Hash:
-        Serialize + DeserializeOwned + Ord + Debug + Send + Sync + 'static,
+    <T as Transaction>::Hash: Serialize + DeserializeOwned + Ord + Debug + Send + Sync + 'static,
     RuntimeServiceId:
         Debug + Sync + Display + 'static + AsServiceId<ClMempoolService<T, RuntimeServiceId>>,
 {
@@ -635,8 +634,7 @@ pub async fn da_get_commitments<
 where
     DaShare: Share,
     <DaShare as Share>::BlobId: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-    <DaShare as Share>::SharesCommitments:
-        Serialize + DeserializeOwned + Send + Sync + 'static,
+    <DaShare as Share>::SharesCommitments: Serialize + DeserializeOwned + Send + Sync + 'static,
     StorageOp: StorageSerde + Send + Sync + 'static,
     <StorageOp as StorageSerde>::Error: Send + Sync,
     DaStorageConverter:
@@ -886,15 +884,8 @@ where
         + Send
         + Sync
         + 'static,
-    <B as DispersedBlobInfo>::BlobId: Ord
-        + Clone
-        + Debug
-        + Hash
-        + Send
-        + Sync
-        + Serialize
-        + for<'de> Deserialize<'de>
-        + 'static,
+    <B as DispersedBlobInfo>::BlobId:
+        Ord + Clone + Debug + Hash + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     SamplingBackend: DaSamplingServiceBackend<SamplingRng, BlobId = <B as DispersedBlobInfo>::BlobId>
         + Send
         + 'static,

--- a/nomos-blend/core/src/cover_traffic.rs
+++ b/nomos-blend/core/src/cover_traffic.rs
@@ -558,7 +558,7 @@ mod tests {
 
         // We wait until one full session has passed, and we make sure not more than the
         // allowed amount of cover messages has been generated.
-        tokio::time::sleep(session_duration).await;
+        time::sleep(session_duration).await;
         drop(task);
 
         // Since by default we don't use any safety buffer, we can verify that EXACTLY
@@ -594,7 +594,7 @@ mod tests {
 
         // We wait until one full (long) session has passed, and we make sure not more
         // than the allowed amount of cover messages has been generated.
-        tokio::time::sleep(session_duration).await;
+        time::sleep(session_duration).await;
         drop(task);
 
         // In this case, we should generate EXACTLY the expected number of messages.
@@ -633,7 +633,7 @@ mod tests {
 
         // We wait until one full session has passed, and we make sure not more than the
         // allowed amount of cover messages has been generated.
-        tokio::time::sleep(session_duration).await;
+        time::sleep(session_duration).await;
         drop(task);
 
         // In this case, we should arrive to exactly `1` messages left, because there
@@ -677,7 +677,7 @@ mod tests {
 
         // We wait until one full session has passed, and we make sure that no cover
         // message is generated at all.
-        tokio::time::sleep(session_duration).await;
+        time::sleep(session_duration).await;
         drop(task);
 
         // In this case, we should have generated `0` messages since all message slots

--- a/nomos-blend/message/src/sphinx/packet.rs
+++ b/nomos-blend/message/src/sphinx/packet.rs
@@ -51,7 +51,7 @@ impl Packet {
             .iter()
             .map(|key_material| key_material.payload_key)
             .collect::<Vec<_>>();
-        let payload = sphinx_packet::payload::Payload::encapsulate_message(
+        let payload = Payload::encapsulate_message(
             payload,
             &payload_keys,
             // sphinx_packet::payload requires this parameter to include the overhead size.
@@ -98,7 +98,7 @@ impl Packet {
         );
 
         // Decrypt one layer of encryption on the payload
-        let payload = sphinx_packet::payload::Payload::from_bytes(&self.payload)?;
+        let payload = Payload::from_bytes(&self.payload)?;
         let payload = payload.unwrap(&routing_keys.payload_key)?;
 
         // Unpack the routing information

--- a/nomos-blend/message/src/sphinx/routing.rs
+++ b/nomos-blend/message/src/sphinx/routing.rs
@@ -40,7 +40,7 @@ impl ConsistentLengthLayeredCipherData for RoutingInformation {
         vec![self.flag]
     }
 
-    const SIZE: usize = std::mem::size_of::<RoutingFlag>();
+    const SIZE: usize = size_of::<RoutingFlag>();
 }
 
 /// Encrypted routing information that will be contained in a packet header.

--- a/nomos-blend/network/src/handler.rs
+++ b/nomos-blend/network/src/handler.rs
@@ -368,12 +368,12 @@ where
 /// Write a message to the stream
 async fn send_msg(mut stream: Stream, msg: Vec<u8>) -> io::Result<Stream> {
     let msg_len: u16 = msg.len().try_into().map_err(|_| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
             format!(
                 "Message length is too big. Got {}, expected {}",
                 msg.len(),
-                std::mem::size_of::<u16>()
+                size_of::<u16>()
             ),
         )
     })?;
@@ -384,7 +384,7 @@ async fn send_msg(mut stream: Stream, msg: Vec<u8>) -> io::Result<Stream> {
 }
 /// Read a message from the stream
 async fn recv_msg(mut stream: Stream) -> io::Result<(Stream, Vec<u8>)> {
-    let mut msg_len = [0; std::mem::size_of::<u16>()];
+    let mut msg_len = [0; size_of::<u16>()];
     stream.read_exact(&mut msg_len).await?;
     let msg_len = u16::from_be_bytes(msg_len) as usize;
 

--- a/nomos-cli/src/cmds/validator.rs
+++ b/nomos-cli/src/cmds/validator.rs
@@ -45,7 +45,7 @@ pub struct Reconstruct {
         value_name = "APP_BLOBS",
         value_parser(parse_app_shares)
     )]
-    pub app_shares: Option<std::vec::Vec<(Index, Vec<DaShare>)>>,
+    pub app_shares: Option<Vec<(Index, Vec<DaShare>)>>,
     /// File with blobs.
     #[clap(short, long)]
     pub file: Option<PathBuf>,
@@ -56,7 +56,7 @@ impl Retrieve {
         clippy::cognitive_complexity,
         reason = "TODO: Address this at some point."
     )]
-    pub fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn run(self) -> Result<(), Box<dyn Error>> {
         let app_id: [u8; 32] = hex::decode(&self.app_id)?
             .try_into()
             .map_err(|_| "Invalid app_id")?;
@@ -102,7 +102,7 @@ async fn retrieve_data(
     range: Range<Index>,
 ) {
     let res = get_app_data_range_from_node::<kzgrs_backend::dispersal::Metadata>(
-        reqwest::Client::new(),
+        Client::new(),
         url,
         app_id,
         range,
@@ -140,7 +140,7 @@ where
 }
 
 impl Reconstruct {
-    pub fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn run(self) -> Result<(), Box<dyn Error>> {
         let app_shares: Vec<(Index, Vec<DaShare>)> = if let Some(shares) = self.app_shares {
             shares
         } else {

--- a/nomos-core/chain-defs/src/proofs/leader_proof.rs
+++ b/nomos-core/chain-defs/src/proofs/leader_proof.rs
@@ -70,7 +70,7 @@ impl LeaderProof for Risc0LeaderProof {
 }
 
 impl Serialize for Risc0LeaderProof {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -79,7 +79,7 @@ impl Serialize for Risc0LeaderProof {
 }
 
 impl<'de> Deserialize<'de> for Risc0LeaderProof {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/nomos-core/cl/Cargo.toml
+++ b/nomos-core/cl/Cargo.toml
@@ -117,11 +117,20 @@ unwrap_used                 = { level = "allow" }
 
 # Explicitly allowed lints
 
+unused_crate_dependencies = { level = "allow" } # Too many false positives especially around benchmarking and binaries, which do not have their own `dependencies` section yet. Plus, we have cargo-machete checking unused deps.
+unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
+
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports   = { level = "warn" }
-redundant_lifetimes = { level = "warn" }
+redundant_imports     = { level = "warn" }
+redundant_lifetimes   = { level = "warn" }
+unused_extern_crates  = { level = "warn" }
+unused_import_braces  = { level = "warn" }
+unused_lifetimes      = { level = "warn" }
+unused_macro_rules    = { level = "warn" }
+unused_qualifications = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
+# When doing so, please update the same table for all crates that are not part of the workspace.
 absolute_paths_not_starting_with_crate       = { level = "allow" }
 ambiguous_negative_literals                  = { level = "allow" }
 closure_returning_async_block                = { level = "allow" }
@@ -164,11 +173,4 @@ unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 unsafe_op_in_unsafe_fn                       = { level = "allow" }
 unstable_features                            = { level = "allow" }
-unused_crate_dependencies                    = { level = "allow" }
-unused_extern_crates                         = { level = "allow" }
-unused_import_braces                         = { level = "allow" }
-unused_lifetimes                             = { level = "allow" }
-unused_macro_rules                           = { level = "allow" }
-unused_qualifications                        = { level = "allow" }
-unused_results                               = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/cl/src/bundle.rs
+++ b/nomos-core/cl/src/bundle.rs
@@ -35,9 +35,7 @@ impl BundleWitness {
     #[must_use]
     pub fn balance(&self) -> BalanceWitness {
         BalanceWitness::combine(
-            self.partials
-                .iter()
-                .map(super::partial_tx::PartialTxWitness::balance),
+            self.partials.iter().map(PartialTxWitness::balance),
             [0u8; 16],
         )
     }
@@ -50,11 +48,7 @@ impl BundleWitness {
     #[must_use]
     pub fn commit(&self) -> Bundle {
         Bundle {
-            partials: self
-                .partials
-                .iter()
-                .map(super::partial_tx::PartialTxWitness::commit)
-                .collect(),
+            partials: self.partials.iter().map(PartialTxWitness::commit).collect(),
         }
     }
 }

--- a/nomos-core/cl/src/input.rs
+++ b/nomos-core/cl/src/input.rs
@@ -21,7 +21,7 @@ pub struct Input {
 pub struct InputWitness {
     pub note: NoteWitness,
     pub nf_sk: NullifierSecret,
-    pub cm_path: Vec<crate::merkle::PathNode>,
+    pub cm_path: Vec<merkle::PathNode>,
 }
 
 impl InputWitness {

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -114,11 +114,20 @@ unwrap_used                 = { level = "allow" }
 
 # Explicitly allowed lints
 
+unused_crate_dependencies = { level = "allow" } # Too many false positives especially around benchmarking and binaries, which do not have their own `dependencies` section yet. Plus, we have cargo-machete checking unused deps.
+unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
+
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports   = { level = "warn" }
-redundant_lifetimes = { level = "warn" }
+redundant_imports     = { level = "warn" }
+redundant_lifetimes   = { level = "warn" }
+unused_extern_crates  = { level = "warn" }
+unused_import_braces  = { level = "warn" }
+unused_lifetimes      = { level = "warn" }
+unused_macro_rules    = { level = "warn" }
+unused_qualifications = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
+# When doing so, please update the same table for all crates that are not part of the workspace.
 absolute_paths_not_starting_with_crate       = { level = "allow" }
 ambiguous_negative_literals                  = { level = "allow" }
 closure_returning_async_block                = { level = "allow" }
@@ -161,11 +170,4 @@ unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 unsafe_op_in_unsafe_fn                       = { level = "allow" }
 unstable_features                            = { level = "allow" }
-unused_crate_dependencies                    = { level = "allow" }
-unused_extern_crates                         = { level = "allow" }
-unused_import_braces                         = { level = "allow" }
-unused_lifetimes                             = { level = "allow" }
-unused_macro_rules                           = { level = "allow" }
-unused_qualifications                        = { level = "allow" }
-unused_results                               = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -121,11 +121,20 @@ unwrap_used                 = { level = "allow" }
 
 # Explicitly allowed lints
 
+unused_crate_dependencies = { level = "allow" } # Too many false positives especially around benchmarking and binaries, which do not have their own `dependencies` section yet. Plus, we have cargo-machete checking unused deps.
+unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
+
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports   = { level = "warn" }
-redundant_lifetimes = { level = "warn" }
+redundant_imports     = { level = "warn" }
+redundant_lifetimes   = { level = "warn" }
+unused_extern_crates  = { level = "warn" }
+unused_import_braces  = { level = "warn" }
+unused_lifetimes      = { level = "warn" }
+unused_macro_rules    = { level = "warn" }
+unused_qualifications = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
+# When doing so, please update the same table for all crates that are not part of the workspace.
 absolute_paths_not_starting_with_crate       = { level = "allow" }
 ambiguous_negative_literals                  = { level = "allow" }
 closure_returning_async_block                = { level = "allow" }
@@ -168,11 +177,4 @@ unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 unsafe_op_in_unsafe_fn                       = { level = "allow" }
 unstable_features                            = { level = "allow" }
-unused_crate_dependencies                    = { level = "allow" }
-unused_extern_crates                         = { level = "allow" }
-unused_import_braces                         = { level = "allow" }
-unused_lifetimes                             = { level = "allow" }
-unused_macro_rules                           = { level = "allow" }
-unused_qualifications                        = { level = "allow" }
-unused_results                               = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/risc0_proofs/bundle_balance/Cargo.toml
+++ b/nomos-core/risc0_proofs/bundle_balance/Cargo.toml
@@ -119,11 +119,20 @@ unwrap_used                 = { level = "allow" }
 
 # Explicitly allowed lints
 
+unused_crate_dependencies = { level = "allow" } # Too many false positives especially around benchmarking and binaries, which do not have their own `dependencies` section yet. Plus, we have cargo-machete checking unused deps.
+unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
+
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports   = { level = "warn" }
-redundant_lifetimes = { level = "warn" }
+redundant_imports     = { level = "warn" }
+redundant_lifetimes   = { level = "warn" }
+unused_extern_crates  = { level = "warn" }
+unused_import_braces  = { level = "warn" }
+unused_lifetimes      = { level = "warn" }
+unused_macro_rules    = { level = "warn" }
+unused_qualifications = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
+# When doing so, please update the same table for all crates that are not part of the workspace.
 absolute_paths_not_starting_with_crate       = { level = "allow" }
 ambiguous_negative_literals                  = { level = "allow" }
 closure_returning_async_block                = { level = "allow" }
@@ -166,11 +175,4 @@ unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 unsafe_op_in_unsafe_fn                       = { level = "allow" }
 unstable_features                            = { level = "allow" }
-unused_crate_dependencies                    = { level = "allow" }
-unused_extern_crates                         = { level = "allow" }
-unused_import_braces                         = { level = "allow" }
-unused_lifetimes                             = { level = "allow" }
-unused_macro_rules                           = { level = "allow" }
-unused_qualifications                        = { level = "allow" }
-unused_results                               = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/risc0_proofs/covenant_nop/Cargo.toml
+++ b/nomos-core/risc0_proofs/covenant_nop/Cargo.toml
@@ -114,11 +114,20 @@ unwrap_used                 = { level = "allow" }
 
 # Explicitly allowed lints
 
+unused_crate_dependencies = { level = "allow" } # Too many false positives especially around benchmarking and binaries, which do not have their own `dependencies` section yet. Plus, we have cargo-machete checking unused deps.
+unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
+
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports   = { level = "warn" }
-redundant_lifetimes = { level = "warn" }
+redundant_imports     = { level = "warn" }
+redundant_lifetimes   = { level = "warn" }
+unused_extern_crates  = { level = "warn" }
+unused_import_braces  = { level = "warn" }
+unused_lifetimes      = { level = "warn" }
+unused_macro_rules    = { level = "warn" }
+unused_qualifications = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
+# When doing so, please update the same table for all crates that are not part of the workspace.
 absolute_paths_not_starting_with_crate       = { level = "allow" }
 ambiguous_negative_literals                  = { level = "allow" }
 closure_returning_async_block                = { level = "allow" }
@@ -161,11 +170,4 @@ unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 unsafe_op_in_unsafe_fn                       = { level = "allow" }
 unstable_features                            = { level = "allow" }
-unused_crate_dependencies                    = { level = "allow" }
-unused_extern_crates                         = { level = "allow" }
-unused_import_braces                         = { level = "allow" }
-unused_lifetimes                             = { level = "allow" }
-unused_macro_rules                           = { level = "allow" }
-unused_qualifications                        = { level = "allow" }
-unused_results                               = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -120,11 +120,20 @@ unwrap_used                 = { level = "allow" }
 
 # Explicitly allowed lints
 
+unused_crate_dependencies = { level = "allow" } # Too many false positives especially around benchmarking and binaries, which do not have their own `dependencies` section yet. Plus, we have cargo-machete checking unused deps.
+unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
+
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports   = { level = "warn" }
-redundant_lifetimes = { level = "warn" }
+redundant_imports     = { level = "warn" }
+redundant_lifetimes   = { level = "warn" }
+unused_extern_crates  = { level = "warn" }
+unused_import_braces  = { level = "warn" }
+unused_lifetimes      = { level = "warn" }
+unused_macro_rules    = { level = "warn" }
+unused_qualifications = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
+# When doing so, please update the same table for all crates that are not part of the workspace.
 absolute_paths_not_starting_with_crate       = { level = "allow" }
 ambiguous_negative_literals                  = { level = "allow" }
 closure_returning_async_block                = { level = "allow" }
@@ -167,11 +176,4 @@ unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 unsafe_op_in_unsafe_fn                       = { level = "allow" }
 unstable_features                            = { level = "allow" }
-unused_crate_dependencies                    = { level = "allow" }
-unused_extern_crates                         = { level = "allow" }
-unused_import_braces                         = { level = "allow" }
-unused_lifetimes                             = { level = "allow" }
-unused_macro_rules                           = { level = "allow" }
-unused_qualifications                        = { level = "allow" }
-unused_results                               = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/risc0_proofs/ptx/Cargo.toml
+++ b/nomos-core/risc0_proofs/ptx/Cargo.toml
@@ -119,11 +119,20 @@ unwrap_used                 = { level = "allow" }
 
 # Explicitly allowed lints
 
+unused_crate_dependencies = { level = "allow" } # Too many false positives especially around benchmarking and binaries, which do not have their own `dependencies` section yet. Plus, we have cargo-machete checking unused deps.
+unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
+
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports   = { level = "warn" }
-redundant_lifetimes = { level = "warn" }
+redundant_imports     = { level = "warn" }
+redundant_lifetimes   = { level = "warn" }
+unused_extern_crates  = { level = "warn" }
+unused_import_braces  = { level = "warn" }
+unused_lifetimes      = { level = "warn" }
+unused_macro_rules    = { level = "warn" }
+unused_qualifications = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
+# When doing so, please update the same table for all crates that are not part of the workspace.
 absolute_paths_not_starting_with_crate       = { level = "allow" }
 ambiguous_negative_literals                  = { level = "allow" }
 closure_returning_async_block                = { level = "allow" }
@@ -166,11 +175,4 @@ unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 unsafe_op_in_unsafe_fn                       = { level = "allow" }
 unstable_features                            = { level = "allow" }
-unused_crate_dependencies                    = { level = "allow" }
-unused_extern_crates                         = { level = "allow" }
-unused_import_braces                         = { level = "allow" }
-unused_lifetimes                             = { level = "allow" }
-unused_macro_rules                           = { level = "allow" }
-unused_qualifications                        = { level = "allow" }
-unused_results                               = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-da/kzgrs-backend/benches/reconstruct.rs
+++ b/nomos-da/kzgrs-backend/benches/reconstruct.rs
@@ -20,7 +20,7 @@ const MB: usize = 1024;
 #[must_use]
 pub fn rand_data(elements_count: usize) -> Vec<u8> {
     let mut buff = vec![0; elements_count * DaEncoderParams::MAX_BLS12_381_ENCODING_CHUNK_SIZE];
-    rand::thread_rng().fill_bytes(&mut buff);
+    thread_rng().fill_bytes(&mut buff);
     buff
 }
 #[divan::bench(consts = [32, 64, 128, 256, 512, 1024], args = [128, 256, 512, 1024, 2048, 4096], sample_count = 1, sample_size = 1)]

--- a/nomos-da/kzgrs-backend/src/common/mod.rs
+++ b/nomos-da/kzgrs-backend/src/common/mod.rs
@@ -195,7 +195,7 @@ where
     D: Deserializer<'de>,
     T: CanonicalDeserialize,
 {
-    let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
+    let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
     let mut cursor = Cursor::new(bytes);
     T::deserialize_compressed(&mut cursor).map_err(serde::de::Error::custom)
 }

--- a/nomos-da/kzgrs-backend/src/dispersal.rs
+++ b/nomos-da/kzgrs-backend/src/dispersal.rs
@@ -27,7 +27,7 @@ impl blob::info::DispersedBlobInfo for BlobInfo {
     }
 
     fn size(&self) -> usize {
-        std::mem::size_of_val(&self.id) + self.metadata.size()
+        size_of_val(&self.id) + self.metadata.size()
     }
 }
 
@@ -74,7 +74,7 @@ impl Metadata {
     )]
     #[must_use]
     pub fn size(&self) -> usize {
-        std::mem::size_of_val(&self.app_id) + std::mem::size_of_val(&self.index)
+        size_of_val(&self.app_id) + size_of_val(&self.index)
     }
 }
 

--- a/nomos-da/kzgrs/src/kzg.rs
+++ b/nomos-da/kzgrs/src/kzg.rs
@@ -99,12 +99,8 @@ mod test {
     const COEFFICIENTS_SIZE: usize = 16;
     static GLOBAL_PARAMETERS: LazyLock<UniversalParams<Bls12_381>> = LazyLock::new(|| {
         let mut rng = thread_rng();
-        KZG10::<Bls12_381, DensePolynomial<Fr>>::setup(
-            COEFFICIENTS_SIZE - 1,
-            true,
-            &mut rng,
-        )
-        .unwrap()
+        KZG10::<Bls12_381, DensePolynomial<Fr>>::setup(COEFFICIENTS_SIZE - 1, true, &mut rng)
+            .unwrap()
     });
 
     static DOMAIN: LazyLock<GeneralEvaluationDomain<Fr>> =

--- a/nomos-da/kzgrs/src/kzg.rs
+++ b/nomos-da/kzgrs/src/kzg.rs
@@ -98,9 +98,9 @@ mod test {
 
     const COEFFICIENTS_SIZE: usize = 16;
     static GLOBAL_PARAMETERS: LazyLock<UniversalParams<Bls12_381>> = LazyLock::new(|| {
-        let mut rng = rand::thread_rng();
+        let mut rng = thread_rng();
         KZG10::<Bls12_381, DensePolynomial<Fr>>::setup(
-            crate::kzg::test::COEFFICIENTS_SIZE - 1,
+            COEFFICIENTS_SIZE - 1,
             true,
             &mut rng,
         )

--- a/nomos-da/kzgrs/src/lib.rs
+++ b/nomos-da/kzgrs/src/lib.rs
@@ -6,8 +6,6 @@ pub mod kzg;
 pub mod bdfg_proving;
 pub mod rs;
 
-use std::mem;
-
 use ark_bls12_381::{Bls12_381, Fr};
 use ark_poly::{univariate::DensePolynomial, GeneralEvaluationDomain};
 use ark_poly_commit::{kzg10, sonic_pc::UniversalParams};
@@ -18,11 +16,11 @@ pub use rs::{decode, encode};
 
 pub type Commitment = kzg10::Commitment<Bls12_381>;
 pub type Proof = kzg10::Proof<Bls12_381>;
-pub type FieldElement = ark_bls12_381::Fr;
+pub type FieldElement = Fr;
 pub type Polynomial = DensePolynomial<Fr>;
 pub type Evaluations = ark_poly::Evaluations<Fr>;
 pub type PolynomialEvaluationDomain = GeneralEvaluationDomain<Fr>;
 
 pub type GlobalParameters = UniversalParams<Bls12_381>;
 
-pub const BYTES_PER_FIELD_ELEMENT: usize = mem::size_of::<Fr>();
+pub const BYTES_PER_FIELD_ELEMENT: usize = size_of::<Fr>();

--- a/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
@@ -332,7 +332,7 @@ where
     ) -> Option<(SubnetworkId, DaShare)> {
         to_disperse
             .get_mut(peer_id)
-            .and_then(std::collections::VecDeque::pop_front)
+            .and_then(VecDeque::pop_front)
     }
 
     pub fn try_wake(&mut self) {

--- a/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
@@ -330,9 +330,7 @@ where
         peer_id: &PeerId,
         to_disperse: &mut HashMap<PeerId, VecDeque<(SubnetworkId, DaShare)>>,
     ) -> Option<(SubnetworkId, DaShare)> {
-        to_disperse
-            .get_mut(peer_id)
-            .and_then(VecDeque::pop_front)
+        to_disperse.get_mut(peer_id).and_then(VecDeque::pop_front)
     }
 
     pub fn try_wake(&mut self) {

--- a/nomos-da/network/core/src/protocols/replication/mod.rs
+++ b/nomos-da/network/core/src/protocols/replication/mod.rs
@@ -238,7 +238,7 @@ mod test {
                 .await
         };
         let join1 = tokio::spawn(task_1);
-        let (sender, mut receiver) = tokio::sync::mpsc::channel::<()>(10);
+        let (sender, mut receiver) = mpsc::channel::<()>(10);
         let (terminate_sender, mut terminate_receiver) = tokio::sync::oneshot::channel::<()>();
         let task_2 = async move {
             swarm_2.dial_and_wait(addr2).await;

--- a/nomos-da/network/core/src/protocols/sampling/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/behaviour.rs
@@ -475,9 +475,8 @@ where
         let peer_id = stream.peer_id;
 
         // If there is a pending task schedule next one
-        if let Some((subnetwork_id, blob_id)) = to_sample
-            .get_mut(&peer_id)
-            .and_then(VecDeque::pop_front)
+        if let Some((subnetwork_id, blob_id)) =
+            to_sample.get_mut(&peer_id).and_then(VecDeque::pop_front)
         {
             let sample_request = sampling::SampleRequest::new(blob_id, subnetwork_id);
             stream_tasks.push(Self::stream_sample(stream, sample_request).boxed());

--- a/nomos-da/network/core/src/protocols/sampling/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/behaviour.rs
@@ -477,7 +477,7 @@ where
         // If there is a pending task schedule next one
         if let Some((subnetwork_id, blob_id)) = to_sample
             .get_mut(&peer_id)
-            .and_then(std::collections::VecDeque::pop_front)
+            .and_then(VecDeque::pop_front)
         {
             let sample_request = sampling::SampleRequest::new(blob_id, subnetwork_id);
             stream_tasks.push(Self::stream_sample(stream, sample_request).boxed());
@@ -558,7 +558,7 @@ impl<Membership: MembershipHandler<Id = PeerId, NetworkId = SubnetworkId> + 'sta
         if let Some((subnetwork_id, blob_id)) = self
             .to_sample
             .get_mut(&peer_id)
-            .and_then(std::collections::VecDeque::pop_front)
+            .and_then(VecDeque::pop_front)
         {
             let control = self.control.clone();
             let sample_request = sampling::SampleRequest::new(blob_id, subnetwork_id);

--- a/nomos-services/api/src/http/cl.rs
+++ b/nomos-services/api/src/http/cl.rs
@@ -31,8 +31,8 @@ where
         + Send
         + Sync
         + 'static,
-    <T as nomos_core::tx::Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    <T as Transaction>::Hash:
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     RuntimeServiceId: Debug + Sync + Display + AsServiceId<ClMempoolService<T, RuntimeServiceId>>,
 {
     let relay = handle.relay().await?;
@@ -65,8 +65,8 @@ where
         + Send
         + Sync
         + 'static,
-    <T as nomos_core::tx::Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    <T as Transaction>::Hash:
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     RuntimeServiceId: Debug + Sync + Display + AsServiceId<ClMempoolService<T, RuntimeServiceId>>,
 {
     let relay = handle.relay().await?;

--- a/nomos-services/api/src/http/consensus/cryptarchia.rs
+++ b/nomos-services/api/src/http/consensus/cryptarchia.rs
@@ -100,7 +100,7 @@ where
         + Sync
         + 'static,
     <Tx as Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     SS: StorageSerde + Send + Sync + 'static,
     SamplingRng: SeedableRng + RngCore,
     SamplingBackend: DaSamplingServiceBackend<SamplingRng, BlobId = BlobId> + Send,
@@ -181,7 +181,7 @@ where
         + Sync
         + 'static,
     <Tx as Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     SS: StorageSerde + Send + Sync + 'static,
     SamplingRng: SeedableRng + RngCore,
     SamplingBackend: DaSamplingServiceBackend<SamplingRng, BlobId = BlobId> + Send,

--- a/nomos-services/api/src/http/da.rs
+++ b/nomos-services/api/src/http/da.rs
@@ -205,7 +205,7 @@ where
         + Sync
         + 'static,
     <Tx as Transaction>::Hash:
-        std::cmp::Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+        Ord + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     C: DispersedBlobInfo<BlobId = [u8; 32]>
         + Clone
         + Debug
@@ -241,7 +241,7 @@ where
     SamplingNetworkAdapter: nomos_da_sampling::network::NetworkAdapter<RuntimeServiceId>,
     SamplingStorage: nomos_da_sampling::storage::DaStorageAdapter<RuntimeServiceId>,
     DaVerifierStorage: nomos_da_verifier::storage::DaStorageAdapter<RuntimeServiceId>,
-    DaVerifierBackend: nomos_da_verifier::backend::VerifierBackend + Send + 'static,
+    DaVerifierBackend: VerifierBackend + Send + 'static,
     DaVerifierBackend::Settings: Clone,
     DaVerifierNetwork: nomos_da_verifier::network::NetworkAdapter<RuntimeServiceId>,
     DaVerifierNetwork::Settings: Clone,

--- a/nomos-services/api/tests/todo.rs
+++ b/nomos-services/api/tests/todo.rs
@@ -132,6 +132,11 @@ fn test_todo() {
 }
 
 mod todo {
+    #![expect(
+        unused_qualifications,
+        reason = "utoipa::path macro prepends some paths which triggers this rustc lint."
+    )]
+
     use std::sync::{Arc, Mutex};
 
     use axum::{
@@ -201,7 +206,7 @@ mod todo {
       get,
       path = "/todo/search",
       params(
-          TodoSearchQuery
+        TodoSearchQuery
       ),
       responses(
           (status = 200, description = "List matching todos by query", body = [Todo])

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -956,7 +956,7 @@ where
     #[instrument(level = "debug", skip(cryptarchia, leader, relays))]
     async fn process_block<State: CryptarchiaState>(
         mut cryptarchia: Cryptarchia<State>,
-        leader: &mut leadership::Leader,
+        leader: &Leader,
         block: Block<ClPool::Item, DaPool::Item>,
         relays: &CryptarchiaConsensusRelays<
             BlendAdapter,

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -883,7 +883,7 @@ where
     )]
     async fn process_block_and_update_state(
         mut cryptarchia: Cryptarchia<Online>,
-        leader: &mut leadership::Leader,
+        leader: &mut Leader,
         block: Block<ClPool::Item, DaPool::Item>,
         previously_pruned_blocks: &mut HashSet<HeaderId>,
         relays: &CryptarchiaConsensusRelays<
@@ -956,7 +956,7 @@ where
     #[instrument(level = "debug", skip(cryptarchia, leader, relays))]
     async fn process_block<State: CryptarchiaState>(
         mut cryptarchia: Cryptarchia<State>,
-        leader: &Leader,
+        leader: &mut Leader,
         block: Block<ClPool::Item, DaPool::Item>,
         relays: &CryptarchiaConsensusRelays<
             BlendAdapter,

--- a/nomos-services/cryptarchia-consensus/src/states.rs
+++ b/nomos-services/cryptarchia-consensus/src/states.rs
@@ -179,7 +179,7 @@ mod tests {
         // Empty ledger state.
         let ledger_state = nomos_ledger::Ledger::new(
             cryptarchia_engine.lib(),
-            nomos_ledger::LedgerState::from_commitments([], 0),
+            LedgerState::from_commitments([], 0),
             ledger_config,
         );
 

--- a/nomos-services/data-availability/network/src/backends/mock/executor.rs
+++ b/nomos-services/data-availability/network/src/backends/mock/executor.rs
@@ -75,7 +75,11 @@ impl<RuntimeServiceId> NetworkBackend<RuntimeServiceId> for MockExecutorBackend 
     type NetworkEvent = Event;
     type Membership = MockMembership;
 
-    fn new(config: Self::Settings, _: OverwatchHandle<RuntimeServiceId>) -> Self {
+    fn new(
+        config: Self::Settings,
+        _: OverwatchHandle<RuntimeServiceId>,
+        _membership: Self::Membership,
+    ) -> Self {
         let (commands_tx, _) = mpsc::channel(BUFFER_SIZE);
         let (events_tx, _) = broadcast::channel(BUFFER_SIZE);
         Self {
@@ -146,7 +150,7 @@ impl MembershipHandler for MockMembership {
         todo!()
     }
 
-    fn get_address(&self, _peer_id: &libp2p::PeerId) -> Option<libp2p::Multiaddr> {
+    fn get_address(&self, _peer_id: &PeerId) -> Option<libp2p::Multiaddr> {
         todo!()
     }
 

--- a/nomos-services/data-availability/network/src/backends/mock/executor.rs
+++ b/nomos-services/data-availability/network/src/backends/mock/executor.rs
@@ -75,13 +75,9 @@ impl<RuntimeServiceId> NetworkBackend<RuntimeServiceId> for MockExecutorBackend 
     type NetworkEvent = Event;
     type Membership = MockMembership;
 
-    fn new(
-        config: Self::Settings,
-        _: OverwatchHandle<RuntimeServiceId>,
-        _membership: Self::Membership,
-    ) -> Self {
-        let (commands_tx, _) = tokio::sync::mpsc::channel(BUFFER_SIZE);
-        let (events_tx, _) = tokio::sync::broadcast::channel(BUFFER_SIZE);
+    fn new(config: Self::Settings, _: OverwatchHandle<RuntimeServiceId>) -> Self {
+        let (commands_tx, _) = mpsc::channel(BUFFER_SIZE);
+        let (events_tx, _) = broadcast::channel(BUFFER_SIZE);
         Self {
             _config: config,
             _commands_tx: commands_tx,

--- a/nomos-services/mempool/src/da/settings.rs
+++ b/nomos-services/mempool/src/da/settings.rs
@@ -17,7 +17,7 @@ pub struct DaMempoolSettings<PoolSettings, NetworkAdapterSettings> {
 impl<PoolSettings, NetworkAdapterSettings> FileBackendSettings
     for DaMempoolSettings<PoolSettings, NetworkAdapterSettings>
 {
-    fn recovery_file(&self) -> &std::path::PathBuf {
+    fn recovery_file(&self) -> &PathBuf {
         &self.recovery_path
     }
 }

--- a/nomos-services/mempool/src/tx/settings.rs
+++ b/nomos-services/mempool/src/tx/settings.rs
@@ -17,7 +17,7 @@ pub struct TxMempoolSettings<PoolSettings, NetworkAdapterSettings> {
 impl<PoolSettings, NetworkAdapterSettings> FileBackendSettings
     for TxMempoolSettings<PoolSettings, NetworkAdapterSettings>
 {
-    fn recovery_file(&self) -> &std::path::PathBuf {
+    fn recovery_file(&self) -> &PathBuf {
         &self.recovery_path
     }
 }

--- a/nomos-services/network/src/backends/libp2p/mod.rs
+++ b/nomos-services/network/src/backends/libp2p/mod.rs
@@ -39,8 +39,8 @@ impl<RuntimeServiceId> NetworkBackend<RuntimeServiceId> for Libp2p {
     type NetworkEvent = Event;
 
     fn new(config: Self::Settings, overwatch_handle: OverwatchHandle<RuntimeServiceId>) -> Self {
-        let (commands_tx, commands_rx) = tokio::sync::mpsc::channel(BUFFER_SIZE);
-        let (events_tx, _) = tokio::sync::broadcast::channel(BUFFER_SIZE);
+        let (commands_tx, commands_rx) = mpsc::channel(BUFFER_SIZE);
+        let (events_tx, _) = broadcast::channel(BUFFER_SIZE);
         let initial_peers = config.initial_peers.clone();
 
         let mut swarm_handler =

--- a/nomos-services/network/src/backends/libp2p/swarm/gossipsub.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm/gossipsub.rs
@@ -101,8 +101,8 @@ impl SwarmHandler {
         }
     }
 
-    pub(super) fn handle_gossipsub_event(&self, event: nomos_libp2p::libp2p::gossipsub::Event) {
-        if let nomos_libp2p::libp2p::gossipsub::Event::Message { message, .. } = event {
+    pub(super) fn handle_gossipsub_event(&self, event: gossipsub::Event) {
+        if let gossipsub::Event::Message { message, .. } = event {
             let message = Event::Message(message);
             if let Err(e) = self.events_tx.send(message) {
                 tracing::error!("Failed to send gossipsub message event: {}", e);

--- a/nomos-services/network/src/backends/libp2p/swarm/mod.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm/mod.rs
@@ -242,7 +242,7 @@ impl SwarmHandler {
 }
 
 const fn exp_backoff(retry: usize) -> Duration {
-    std::time::Duration::from_secs(BACKOFF.pow(retry as u32))
+    Duration::from_secs(BACKOFF.pow(retry as u32))
 }
 
 #[cfg(test)]

--- a/nomos-services/network/src/backends/mock.rs
+++ b/nomos-services/network/src/backends/mock.rs
@@ -142,7 +142,7 @@ pub enum MockBackendMessage {
     },
 }
 
-impl core::fmt::Debug for MockBackendMessage {
+impl Debug for MockBackendMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::BootProducer { .. } => write!(f, "BootProducer"),

--- a/nomos-services/sdp/src/adapters/declaration/repository.rs
+++ b/nomos-services/sdp/src/adapters/declaration/repository.rs
@@ -23,7 +23,7 @@ impl ledger::DeclarationsRepository for LedgerDeclarationAdapter {
 
     async fn update(
         &self,
-        _declaration_update: nomos_sdp_core::DeclarationInfo,
+        _declaration_update: DeclarationInfo,
     ) -> Result<(), DeclarationsRepositoryError> {
         todo!()
     }

--- a/nomos-services/storage/src/backends/rocksdb.rs
+++ b/nomos-services/storage/src/backends/rocksdb.rs
@@ -68,7 +68,7 @@ where
     SerdeOp: StorageSerde + Send + Sync + 'static,
 {
     type Settings = RocksBackendSettings;
-    type Error = rocksdb::Error;
+    type Error = Error;
     type Transaction = Transaction;
     type SerdeOperator = SerdeOp;
 
@@ -121,7 +121,7 @@ where
     async fn load(&mut self, key: &[u8]) -> Result<Option<Bytes>, <Self as StorageBackend>::Error> {
         self.rocks
             .get(key)
-            .map(|opt| opt.map(std::convert::Into::into))
+            .map(|opt| opt.map(Into::into))
     }
 
     async fn load_prefix(
@@ -211,7 +211,7 @@ mod test {
             db.put(key, value)?;
             let result = db.get(key)?;
             db.delete(key)?;
-            Ok(result.map(std::convert::Into::into))
+            Ok(result.map(Into::into))
         });
         let result = db.execute(txn).await??;
         assert_eq!(result, Some(b"bar".as_ref().into()));

--- a/nomos-services/storage/src/backends/rocksdb.rs
+++ b/nomos-services/storage/src/backends/rocksdb.rs
@@ -119,9 +119,7 @@ where
     }
 
     async fn load(&mut self, key: &[u8]) -> Result<Option<Bytes>, <Self as StorageBackend>::Error> {
-        self.rocks
-            .get(key)
-            .map(|opt| opt.map(Into::into))
+        self.rocks.get(key).map(|opt| opt.map(Into::into))
     }
 
     async fn load_prefix(

--- a/nomos-tracing/src/filter/envfilter.rs
+++ b/nomos-tracing/src/filter/envfilter.rs
@@ -20,5 +20,5 @@ pub fn create_envfilter_layer(
         .collect::<Vec<_>>()
         .join(",");
 
-    EnvFilter::try_new(filter_string).map_err(std::convert::Into::into)
+    EnvFilter::try_new(filter_string).map_err(Into::into)
 }

--- a/nomos-tracing/src/logging/local.rs
+++ b/nomos-tracing/src/logging/local.rs
@@ -30,7 +30,7 @@ where
 {
     let (non_blocking, guard) = tracing_appender::non_blocking(writer);
 
-    let layer = tracing_subscriber::fmt::Layer::new()
+    let layer = Layer::new()
         .with_level(true)
         .with_writer(non_blocking);
 

--- a/nomos-tracing/src/logging/local.rs
+++ b/nomos-tracing/src/logging/local.rs
@@ -30,9 +30,7 @@ where
 {
     let (non_blocking, guard) = tracing_appender::non_blocking(writer);
 
-    let layer = Layer::new()
-        .with_level(true)
-        .with_writer(non_blocking);
+    let layer = Layer::new().with_level(true).with_writer(non_blocking);
 
     (layer, guard)
 }

--- a/nomos-tracing/src/panic.rs
+++ b/nomos-tracing/src/panic.rs
@@ -7,11 +7,7 @@ pub fn panic_hook(panic_info: &PanicHookInfo) {
     let payload = panic_info.payload();
 
     let payload = payload.downcast_ref::<&str>().map_or_else(
-        || {
-            payload
-                .downcast_ref::<String>()
-                .map(String::as_str)
-        },
+        || payload.downcast_ref::<String>().map(String::as_str),
         |s| Some(&**s),
     );
 

--- a/nomos-tracing/src/panic.rs
+++ b/nomos-tracing/src/panic.rs
@@ -10,12 +10,12 @@ pub fn panic_hook(panic_info: &PanicHookInfo) {
         || {
             payload
                 .downcast_ref::<String>()
-                .map(std::string::String::as_str)
+                .map(String::as_str)
         },
         |s| Some(&**s),
     );
 
-    let location = panic_info.location().map(std::string::ToString::to_string);
+    let location = panic_info.location().map(ToString::to_string);
     let backtrace = Backtrace::capture();
     let note = (backtrace.status() == BacktraceStatus::Disabled)
         .then_some("run with RUST_BACKTRACE=1 environment variable to display a backtrace");

--- a/nomos-tracing/src/tracing/otlp.rs
+++ b/nomos-tracing/src/tracing/otlp.rs
@@ -47,7 +47,7 @@ where
 
     global::set_text_map_propagator(TraceContextPropagator::new());
     global::set_tracer_provider(tracer_provider.clone());
-    let tracer: opentelemetry_sdk::trace::Tracer = tracer_provider.tracer("NomosTracer");
+    let tracer: Tracer = tracer_provider.tracer("NomosTracer");
 
     Ok(OpenTelemetryLayer::new(tracer))
 }

--- a/testnet/cfgsync/src/repo.rs
+++ b/testnet/cfgsync/src/repo.rs
@@ -113,7 +113,7 @@ impl ConfigRepo {
             if self.waiting_hosts.lock().unwrap().len() >= self.n_hosts {
                 break;
             }
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 }

--- a/tests/src/nodes/mod.rs
+++ b/tests/src/nodes/mod.rs
@@ -14,7 +14,7 @@ fn create_tempdir() -> std::io::Result<TempDir> {
     // It's easier to use the current location instead of OS-default tempfile
     // location because Github Actions can easily access files in the current
     // location using wildcard to upload them as artifacts.
-    tempfile::TempDir::new_in(std::env::current_dir()?)
+    TempDir::new_in(std::env::current_dir()?)
 }
 
 fn persist_tempdir(tempdir: &mut TempDir, label: &str) -> std::io::Result<()> {

--- a/tests/src/tests/cryptarchia/happy.rs
+++ b/tests/src/tests/cryptarchia/happy.rs
@@ -46,7 +46,7 @@ async fn happy_test(topology: &Topology) {
                         .await
                         .join(" | ")
                 );
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                tokio::time::sleep(Duration::from_millis(100)).await;
             }
             } => {}
         }


### PR DESCRIPTION
## 1. What does this PR implement?

PR built on top of https://github.com/logos-co/nomos/pull/1337. A review of that PR is recommended before reviewing this one.

We ignore, i.e., keep allowing, the following allow-by-default rustc lints:

* [`unused_crate_dependencies`](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies): too many false positives, especially for bench and bin targets.
* [`unused_results`](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#unused-results): we already have Clippy lints for missing `must_use` result handling. This is for ALL results, which is way too verbose.

We enforce the following lints:
* [`unused_extern_crates`](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#unused-extern-crates)
* [`unused_import_braces`](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#unused-import-braces)
* [`unused_lifetimes`](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#unused-lifetimes)
* [`unused_macro_rules`](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#unused-macro-rules)
* [`unused_qualifications`](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#unused-qualifications) -> this is the only one that triggered quite a bit of changes, since we were over-qualifying types and paths that were already in scope

I apply the new lints to the workspace, which passes it on to all members, and on the crates which are not part of the workspace, which unfortunately need manual editing.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
