### PR TITLE
feat: add dry-run capabilities to binaries and add checks in CI

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -197,19 +197,17 @@ jobs:
       - name: Run the node binary to check the config file validity
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:
-          CONFIG_FILE_PATH: nodes/nomos-node/config.yaml
           RISC0_SKIP_BUILD: true
         with:
           command: run
-          args: --all-features -p nomos-node ${{ env.CONFIG_FILE_PATH }} --check-config
+          args: --all-features -p nomos-node nodes/nomos-node/config.yaml --check-config
       - name: Run the executor binary to check the config file validity
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:
-          CONFIG_FILE_PATH: nodes/nomos-node/config.yaml
           RISC0_SKIP_BUILD: true
         with:
           command: run
-          args: --all-features -p nomos-executor ${{ env.CONFIG_FILE_PATH }} --check-config
+          args: --all-features -p nomos-executor nodes/nomos-executor/config.yaml --check-config
       - name: Cargo test
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -191,15 +191,11 @@ jobs:
       # We build AND run the binaries that are also used in the integration tests later on.
       - name: Run the node binary to check the config file validity
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
-        env:
-          RISC0_SKIP_BUILD: true
         with:
           command: run
           args: --all-features -p nomos-node nodes/nomos-node/config.yaml --check-config
       - name: Run the executor binary to check the config file validity
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
-        env:
-          RISC0_SKIP_BUILD: true
         with:
           command: run
           args: --all-features -p nomos-executor nodes/nomos-executor/config.yaml --check-config

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -188,12 +188,7 @@ jobs:
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ join(matrix.os, '_') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build required binaries
-        uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
-        with:
-          command: build
-          args: --all-features -p nomos-node -p nomos-executor
-      # We put these checks here so we re-use the output of the binaries compilations at the previous step.
+      # We build AND run the binaries that are also used in the integration tests later on.
       - name: Run the node binary to check the config file validity
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -193,6 +193,23 @@ jobs:
         with:
           command: build
           args: --all-features -p nomos-node -p nomos-executor
+      # We put these checks here so we re-use the output of the binaries compilations at the previous step.
+      - name: Run the node binary to check the config file validity
+        uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
+        env:
+          CONFIG_FILE_PATH: nodes/nomos-node/config.yaml
+          RISC0_SKIP_BUILD: true
+        with:
+          command: run
+          args: --all-features -p nomos-node ${{ env.CONFIG_FILE_PATH }} --check-config
+      - name: Run the executor binary to check the config file validity
+        uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
+        env:
+          CONFIG_FILE_PATH: nodes/nomos-node/config.yaml
+          RISC0_SKIP_BUILD: true
+        with:
+          command: run
+          args: --all-features -p nomos-executor ${{ env.CONFIG_FILE_PATH }} --check-config
       - name: Cargo test
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:

--- a/nodes/nomos-executor/config.yaml
+++ b/nodes/nomos-executor/config.yaml
@@ -140,27 +140,29 @@ blend:
         ]
 da_network:
   backend:
-    node_key: ea1e1dcc31612bd20987f017f0ca435cd2a59a4bd9fd6e14883b4803ae3b803d
-    listening_address: /ip4/127.0.0.1/udp/8716/quic-v1
-    policy_settings:
-      min_dispersal_peers: 1
-      min_replication_peers: 1
-      max_dispersal_failures: 3
-      max_sampling_failures: 3
-      max_replication_failures: 3
-      malicious_threshold: 5
-    monitor_settings:
-      failure_time_window: "10.0"
-      time_decay_factor: "0.8"
-    balancer_interval:
-      secs: 5
-      nanos: 0
-    redial_cooldown:
-      secs: 5
-      nanos: 0
-    replication_settings:
-      seen_message_cache_size: 1000
-      seen_message_ttl: "3600.0"
+    validator_settings:
+      node_key: ea1e1dcc31612bd20987f017f0ca435cd2a59a4bd9fd6e14883b4803ae3b803d
+      listening_address: /ip4/127.0.0.1/udp/8716/quic-v1
+      policy_settings:
+        min_dispersal_peers: 1
+        min_replication_peers: 1
+        max_dispersal_failures: 3
+        max_sampling_failures: 3
+        max_replication_failures: 3
+        malicious_threshold: 5
+      monitor_settings:
+        failure_time_window: "10.0"
+        time_decay_factor: "0.8"
+      balancer_interval:
+        secs: 5
+        nanos: 0
+      redial_cooldown:
+        secs: 5
+        nanos: 0
+      replication_settings:
+        seen_message_cache_size: 1000
+        seen_message_ttl: "3600.0"
+    num_subnets: 2
   membership:
     assignations:
       - - 12D3KooWA5LkQcuefjUBTktxCXUQ4rx4PcqRY1tgbSpV9eZDHWir
@@ -172,6 +174,18 @@ da_network:
     addressbook:
       12D3KooWA5LkQcuefjUBTktxCXUQ4rx4PcqRY1tgbSpV9eZDHWir: /ip4/127.0.0.1/udp/8717/quic-v1/p2p/12D3KooWA5LkQcuefjUBTktxCXUQ4rx4PcqRY1tgbSpV9eZDHWir
       12D3KooWKD62Q1nAAMHeV2Cx3rNNMzjgHkTT2edFMzHZ5ur7sGnh: /ip4/127.0.0.1/udp/8716/quic-v1/p2p/12D3KooWKD62Q1nAAMHeV2Cx3rNNMzjgHkTT2edFMzHZ5ur7sGnh
+da_dispersal:
+  backend:
+    encoder_settings:
+      num_columns: 2
+      with_cache: false
+      global_params_path: /tmp
+    dispersal_timeout: [20, 0]
+    mempool_strategy:
+      !SampleSubnetworks
+        sample_threshold: 2
+        timeout: [10, 0]
+        cooldown: [0, 100]
 da_indexer:
   storage:
     blob_storage_directory: ./

--- a/nodes/nomos-executor/executor/src/main.rs
+++ b/nodes/nomos-executor/executor/src/main.rs
@@ -16,6 +16,10 @@ use overwatch::overwatch::OverwatchRunner;
 struct Args {
     /// Path for a yaml-encoded network config file
     config: std::path::PathBuf,
+    /// Dry-run flag. If active, the binary will try to deserialize the config
+    /// file and then exit.
+    #[clap(long = "check-config", action)]
+    check_config_only: bool,
     /// Overrides log config.
     #[clap(flatten)]
     log: LogArgs,
@@ -40,6 +44,7 @@ fn main() -> Result<()> {
         network: network_args,
         blend: blend_args,
         cryptarchia: cryptarchia_args,
+        check_config_only,
     } = Args::parse();
     let config = serde_yaml::from_reader::<_, ExecutorConfig>(std::fs::File::open(config)?)?
         .update_from_args(
@@ -49,6 +54,15 @@ fn main() -> Result<()> {
             http_args,
             cryptarchia_args,
         )?;
+
+    #[expect(
+        clippy::non_ascii_literal,
+        reason = "Use of green checkmark for better UX."
+    )]
+    if check_config_only {
+        println!("Config file is valid! ✅");
+        return Ok(());
+    }
 
     let app = OverwatchRunner::<NomosExecutor>::run(
         NomosExecutorServiceSettings {

--- a/nodes/nomos-node/node/src/main.rs
+++ b/nodes/nomos-node/node/src/main.rs
@@ -16,6 +16,10 @@ use overwatch::overwatch::OverwatchRunner;
 struct Args {
     /// Path for a yaml-encoded network config file
     config: std::path::PathBuf,
+    /// Dry-run flag. If active, the binary will try to deserialize the config
+    /// file and then exit.
+    #[clap(long = "check-config", action)]
+    check_config_only: bool,
     /// Overrides log config.
     #[clap(flatten)]
     log: LogArgs,
@@ -35,6 +39,7 @@ struct Args {
 fn main() -> Result<()> {
     let Args {
         config,
+        check_config_only,
         log: log_args,
         http: http_args,
         network: network_args,
@@ -49,6 +54,15 @@ fn main() -> Result<()> {
             http_args,
             cryptarchia_args,
         )?;
+
+    #[expect(
+        clippy::non_ascii_literal,
+        reason = "Use of green checkmark for better UX."
+    )]
+    if check_config_only {
+        println!("Config file is valid! ✅");
+        return Ok(());
+    }
 
     let app = OverwatchRunner::<Nomos>::run(
         NomosServiceSettings {


### PR DESCRIPTION
## 1. What does this PR implement?

We add a boolean flag that allows us to dry-run a binary and exit right after the config file is deserialized, to only check for its validity. This can be enabled with the `--check-config` on both binaries. The new capability is integrated into our CI, in the test job, to re-use the binaries that are anyway built for integration tests.

I also tried to add the [`deny_unknown_fields`](https://serde.rs/container-attrs.html#deny_unknown_fields) to the overarching config objects, but it seems they do not work when `flatten` is used, which we do, and it needs further investigation. So right now the checks fail if a field is missing but do not detect if there are unused fields. Worth looking into it in the future.

I also fixed the config files by using the values used in integration tests.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
