### PR TITLE
fix(cryptarchia): Fix misbehaviour due to pruning condition and flaky `two_nodes_happy` test.

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -399,42 +399,43 @@ where
         &self.local_chain
     }
 
-    /// Prune all blocks that are included in forks that diverged at or before
-    /// the `depth`th block from the current local chain.
-    ///
-    /// For example, if the tip of the canonical chain is at height 10 (i.e., 11
-    /// blocks long), calling `self.prune_forks(10)` will remove any forks
-    /// stemming from the genesis block, with height `0`, which is the 10th
-    /// block in the past.
-    ///
-    /// This function does not apply any particular logic when evaluating forks
-    /// other than the height at which they diverged from the local
-    /// canonical chain.
-    ///
+    /// Prune all blocks that are included in forks that diverged before
+    /// the `max_div_depth`-th block from the current local chain tip.
     /// It returns the block IDs that were part of the pruned forks.
-    pub fn prune_forks(&mut self, depth: u64) -> impl Iterator<Item = Id> + '_ {
+    ///
+    /// For example,
+    /// Given a block tree:
+    ///               b6
+    ///             /
+    /// G - b1 - b2 - b3 - b4 - b5 == local chain tip
+    ///                  \
+    ///                    b7
+    /// Calling `prune_forks(2)` will remove `b6` because it is diverged from
+    /// `b2`, which is deeper than the 2nd block `b3` from the local chain tip.
+    /// The `b7` is not removed since it is diverged from `b3`.
+    pub fn prune_forks(&mut self, max_div_depth: u64) -> impl Iterator<Item = Id> + '_ {
         #[expect(
             clippy::needless_collect,
             reason = "We need to collect since we cannot borrow both immutably (in `self.prunable_forks`) and mutably (in `self.prune_fork`) at the same time."
         )]
         // Collect prunable forks first to avoid borrowing issues
-        let forks: Vec<_> = self.prunable_forks(depth).collect();
+        let forks: Vec<_> = self.prunable_forks(max_div_depth).collect();
         forks
             .into_iter()
             .flat_map(move |prunable_fork_info| self.prune_fork(&prunable_fork_info))
     }
 
-    /// Get an iterator over the forks that can be pruned given the provided
-    /// depth.
-    ///
-    /// This means that all forks that diverged from the canonical chain at or
-    /// before the provided `depth` height are returned.
-    pub fn prunable_forks(&self, depth: u64) -> impl Iterator<Item = ForkDivergenceInfo<Id>> + '_ {
+    /// Get an iterator over the prunable forks that diverged before
+    /// the `max_div_depth`-th block from the current local chain tip.
+    pub fn prunable_forks(
+        &self,
+        max_div_depth: u64,
+    ) -> impl Iterator<Item = ForkDivergenceInfo<Id>> + '_ {
         let local_chain = self.local_chain;
-        let Some(target_height) = local_chain.length.checked_sub(depth) else {
+        let Some(deepest_div_block) = local_chain.length.checked_sub(max_div_depth) else {
             tracing::debug!(
                 target: LOG_TARGET,
-                "No prunable fork, the canonical chain is not longer than the provided depth. Canonical chain length: {}, provided depth: {}", local_chain.length, depth
+                "No prunable fork, the canonical chain is not longer than the provided depth. Canonical chain length: {}, provided max_div_depth: {}", local_chain.length, max_div_depth
             );
             return Box::new(core::iter::empty())
                 as Box<dyn Iterator<Item = ForkDivergenceInfo<Id>>>;
@@ -443,7 +444,8 @@ where
             // We calculate LCA once and store it in `ForkInfo` so it can be consumed
             // elsewhere without the need to re-calculate it.
             let lca = self.branches.lca(&local_chain, &fork);
-            (lca.length < target_height).then_some(ForkDivergenceInfo { tip: fork, lca })
+            // If the fork is diverged deeper than `deepest_div_block`, it's prunable.
+            (lca.length < deepest_div_block).then_some(ForkDivergenceInfo { tip: fork, lca })
         }))
     }
 
@@ -809,6 +811,9 @@ pub mod tests {
             // Add a fork from block 39
             .receive_block([101; 32], hash(&39u64), 40.into())
             .expect("test block to be applied successfully.")
+            // Add a fork from block 40
+            .receive_block([102; 32], hash(&40u64), 41.into())
+            .expect("test block to be applied successfully.")
             .online();
         let mut chain = chain_pre.clone();
         let pruned_blocks = chain.prune_forks(10);
@@ -817,11 +822,18 @@ pub mod tests {
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));
         assert!(!chain.branches.tips.contains(&[100; 32]));
         assert!(!chain.branches.branches.contains_key(&[100; 32]));
-        // Fork at block 40 was not pruned.
+        // Fork at block 39 was not pruned because it is diverged
+        // at the 10th block from the local chain tip.
         assert!(chain_pre.branches.tips.contains(&[101; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[101; 32]));
         assert!(chain.branches.tips.contains(&[101; 32]));
         assert!(chain.branches.branches.contains_key(&[101; 32]));
+        // Fork at block 40 was not pruned because it is diverged
+        // after the 10th block from the local chain tip.
+        assert!(chain_pre.branches.tips.contains(&[102; 32]));
+        assert!(chain_pre.branches.branches.contains_key(&[102; 32]));
+        assert!(chain.branches.tips.contains(&[102; 32]));
+        assert!(chain.branches.branches.contains_key(&[102; 32]));
     }
 
     #[test]
@@ -844,12 +856,12 @@ pub mod tests {
             pruned_blocks.collect::<HashSet<_>>(),
             [[100; 32], [200; 32]].into()
         );
-        // First fork at block 39 was pruned.
+        // First fork at block 38 was pruned.
         assert!(chain_pre.branches.tips.contains(&[100; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));
         assert!(!chain.branches.tips.contains(&[100; 32]));
         assert!(!chain.branches.branches.contains_key(&[100; 32]));
-        // Second fork at block 39 was pruned.
+        // Second fork at block 38 was pruned.
         assert!(chain_pre.branches.tips.contains(&[200; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[200; 32]));
         assert!(!chain.branches.tips.contains(&[200; 32]));

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -443,7 +443,7 @@ where
             // We calculate LCA once and store it in `ForkInfo` so it can be consumed
             // elsewhere without the need to re-calculate it.
             let lca = self.branches.lca(&local_chain, &fork);
-            (lca.length <= target_height).then_some(ForkDivergenceInfo { tip: fork, lca })
+            (lca.length < target_height).then_some(ForkDivergenceInfo { tip: fork, lca })
         }))
     }
 
@@ -801,12 +801,13 @@ pub mod tests {
 
     #[test]
     fn pruning_with_single_fork_old_enough() {
+        // Create a chain with 50 blocks (0 to 49).
         let chain_pre = create_canonical_chain(50.try_into().unwrap(), None)
-            // Add a fork from block 39
-            .receive_block([100; 32], hash(&39u64), 40.into())
+            // Add a fork from block 38
+            .receive_block([100; 32], hash(&38u64), 39.into())
             .expect("test block to be applied successfully.")
-            // Add a fork from block 40
-            .receive_block([101; 32], hash(&40u64), 41.into())
+            // Add a fork from block 39
+            .receive_block([101; 32], hash(&39u64), 40.into())
             .expect("test block to be applied successfully.")
             .online();
         let mut chain = chain_pre.clone();
@@ -825,15 +826,16 @@ pub mod tests {
 
     #[test]
     fn pruning_with_multiple_forks_old_enough() {
+        // Create a chain with 50 blocks (0 to 49).
         let chain_pre = create_canonical_chain(50.try_into().unwrap(), None)
-            // Add a first fork from block 39
-            .receive_block([100; 32], hash(&39u64), 40.into())
+            // Add a first fork from block 38
+            .receive_block([100; 32], hash(&38u64), 39.into())
             .expect("test block to be applied successfully.")
-            // Add a second fork from block 39
-            .receive_block([200; 32], hash(&39u64), 40.into())
+            // Add a second fork from block 38
+            .receive_block([200; 32], hash(&38u64), 39.into())
             .expect("test block to be applied successfully.")
-            // Add a fork from block 40
-            .receive_block([101; 32], hash(&40u64), 41.into())
+            // Add a fork from block 39
+            .receive_block([101; 32], hash(&39u64), 40.into())
             .expect("test block to be applied successfully.")
             .online();
         let mut chain = chain_pre.clone();
@@ -861,15 +863,16 @@ pub mod tests {
 
     #[test]
     fn pruning_fork_with_multiple_tips() {
+        // Create a chain with 50 blocks (0 to 49).
         let chain_pre = create_canonical_chain(50.try_into().unwrap(), None)
-            // Add a 2-block fork from block 39
-            .receive_block([100; 32], hash(&39u64), 40.into())
+            // Add a 2-block fork from block 38
+            .receive_block([100; 32], hash(&38u64), 39.into())
             .expect("test block to be applied successfully.")
-            .receive_block([101; 32], [100; 32], 41.into())
+            .receive_block([101; 32], [100; 32], 40.into())
             .expect("test block to be applied successfully.")
             // Add a second fork from the first divergent fork block, so that the fork has two
             // tips
-            .receive_block([200; 32], [100; 32], 42.into())
+            .receive_block([200; 32], [100; 32], 41.into())
             .expect("test block to be applied successfully.")
             .online();
         let mut chain = chain_pre.clone();

--- a/nomos-services/cryptarchia-consensus/src/states.rs
+++ b/nomos-services/cryptarchia-consensus/src/states.rs
@@ -199,25 +199,22 @@ mod tests {
             .unwrap();
 
         // We configured `k = 2`, and since the canonical chain is 4-block long (blocks
-        // `0` to `4`), it means that all forks diverging from and before 2
-        // blocks in the past are considered prunable, which are blocks `4` and
-        // `5` belonging to the first fork from genesis, block `6` belonging to the
-        // second fork from genesis, and block `7` belonging to the fork from block
-        // `1`. Block `8` is excluded since it diverged from block `2` which is
-        // not yet finalized, as it is only 1 block past, which is less than the
-        // configured `k = 2`.
+        // `0` to `3`), it means that all forks diverging before 2
+        // blocks in the past are considered prunable.
+        // That is:
+        // - Blocks `3` and `4`, belonging to the first fork from genesis.
+        // - Block `6` belonging to the second fork from genesis.
+        // On the other hand:
+        // - Block `7` is not pruned since it diverged from block `1`, which is the LIB.
+        // - Block `8` is not pruned since it diverged from block `2`, which is 1 block
+        //   younger
+        // than LIB.
         assert_eq!(
             recovery_state
                 .prunable_blocks
                 .into_iter()
                 .collect::<HashSet<_>>(),
-            [
-                [4; 32].into(),
-                [5; 32].into(),
-                [6; 32].into(),
-                [7; 32].into()
-            ]
-            .into()
+            [[4; 32].into(), [5; 32].into(), [6; 32].into(),].into()
         );
 
         // Test when additional blocks are included.
@@ -242,7 +239,6 @@ mod tests {
                 [4; 32].into(),
                 [5; 32].into(),
                 [6; 32].into(),
-                [7; 32].into(),
                 [255; 32].into()
             ]
             .into()

--- a/nomos-services/cryptarchia-consensus/src/states.rs
+++ b/nomos-services/cryptarchia-consensus/src/states.rs
@@ -146,7 +146,13 @@ mod tests {
                 cryptarchia_engine_config,
             );
 
-            // Add 3 more blocks to canonical chain. Blocks `0`, `1`, `2` and `3` represent
+            //      b4 - b5
+            //    /
+            // b0 - b1 - b2 - b3 == local chain tip
+            //    \    \    \
+            //      b6   b7   b8
+            //
+            // Add 3 more blocks to canonical chain. `b0`, `b1`, `b2`, and `b3` represent
             // the canonical chain now.
             cryptarchia = cryptarchia
                 .receive_block([1; 32].into(), genesis_header_id, 1.into())
@@ -198,17 +204,16 @@ mod tests {
             )
             .unwrap();
 
-        // We configured `k = 2`, and since the canonical chain is 4-block long (blocks
-        // `0` to `3`), it means that all forks diverging before 2
-        // blocks in the past are considered prunable.
+        // We configured `k = 2`, and since the canonical chain is 4-block long (`b0` to
+        // `b3`), it means that all forks diverging before 2 blocks in the past
+        // are considered prunable.
         // That is:
-        // - Blocks `3` and `4`, belonging to the first fork from genesis.
-        // - Block `6` belonging to the second fork from genesis.
+        // - `b3` and `b4`, belonging to the first fork from genesis.
+        // - `b6` belonging to the second fork from genesis.
         // On the other hand:
-        // - Block `7` is not pruned since it diverged from block `1`, which is the LIB.
-        // - Block `8` is not pruned since it diverged from block `2`, which is 1 block
-        //   younger
-        // than LIB.
+        // - `b7` is not pruned since it diverged from `b1`, which is the LIB.
+        // - `b8` is not pruned since it diverged from `b2`, which is 1 block younger
+        //   than LIB.
         assert_eq!(
             recovery_state
                 .prunable_blocks

--- a/nomos-services/network/src/backends/libp2p/swarm/gossipsub.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm/gossipsub.rs
@@ -62,7 +62,7 @@ impl SwarmHandler {
 
         match self.swarm.broadcast(&topic, message.to_vec()) {
             Ok(id) => {
-                tracing::debug!("broadcasted message with id: {id} tp topic: {topic}");
+                tracing::debug!("Broadcasted message with id: {id} to topic: {topic}");
                 // self-notification because libp2p doesn't do it
                 if self.swarm.is_subscribed(&topic) {
                     log_error!(self.pubsub_messages_tx.send(gossipsub::Message {

--- a/tests/src/tests/cryptarchia/happy.rs
+++ b/tests/src/tests/cryptarchia/happy.rs
@@ -66,7 +66,6 @@ async fn happy_test(topology: &Topology) {
 }
 
 #[tokio::test]
-#[ignore = "test is executed separately to allow other integration tests run, unignore when stable"]
 async fn two_nodes_happy() {
     let topology = Topology::spawn(TopologyConfig::two_validators()).await;
     happy_test(&topology).await;


### PR DESCRIPTION
## 1. What does this PR implement?
After investigating the `two_nodes_happy` test for a while, I realised that when the two nodes proposed blocks for the same slot their forks would get immediately pruned off. That'd happen even if the forks were happening from LIB (or genesis). Thus:
- Fix a block pruning condition that was pruning forks older than (and including) selected depth (e.g.: LIB), instead of strictly older.
- Fix flaky behaviour on `two_nodes_happy` test.

Closes: https://github.com/logos-co/nomos/issues/1309 
Closes: https://github.com/logos-co/nomos/issues/1304

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
