### PR TITLE
chore(ci): two_nodes_happy is not ignored anymore

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -206,15 +206,6 @@ jobs:
           command: test
           # We don't test benches as they take 6h+, leading to a timeout
           args: --all --lib --bins --tests --examples --all-features
-      - name: Cargo test two_nodes_happy
-        if: always()
-        uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72 # Version 1.0.1
-        env:
-          RISC0_DEV_MODE: true
-          CONSENSUS_SLOT_TIME: 5
-        with:
-          command: test
-          args: -p tests two_nodes_happy -- --ignored
       - name: Update Cargo cache
         if: success() || failure()
         uses: ./.github/actions/update-cargo-cache


### PR DESCRIPTION
## 1. What does this PR implement?

Remove the CI step that runs `two_nodes_happy`, since the test is run in the main test run, and this specific job does not run any tests anyway, at the moment.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
