### PR TITLE
feat(chain): network adapter logic for orphan blocks download

### DIFF
--- a/nomos-libp2p/src/behaviour/kademlia/behaviour_ext.rs
+++ b/nomos-libp2p/src/behaviour/kademlia/behaviour_ext.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use libp2p::{kad::QueryId, Multiaddr, PeerId, StreamProtocol};
+use libp2p::{
+    kad::{PeerInfo, QueryId},
+    Multiaddr, PeerId, StreamProtocol,
+};
 
 use crate::behaviour::Behaviour;
 
@@ -30,5 +33,30 @@ impl Behaviour {
 
     pub(crate) fn kademlia_get_closest_peers(&mut self, peer_id: PeerId) -> QueryId {
         self.kademlia.get_closest_peers(peer_id)
+    }
+
+    pub(crate) fn kademlia_discovered_peers(&mut self) -> Vec<PeerInfo> {
+        let Some(kademlia) = self.kademlia.as_mut() else {
+            tracing::error!("kademlia is not enabled");
+            return Vec::new();
+        };
+
+        // get all buckets and in each buket, peers with addresses
+        kademlia
+            .kbuckets()
+            .flat_map(|bucket| {
+                bucket
+                    .iter()
+                    .filter_map(|entry| {
+                        let peer_id = *entry.node.key.preimage();
+                        let addresses: Vec<_> = entry.node.value.iter().cloned().collect();
+                        (!addresses.is_empty()).then_some(PeerInfo {
+                            peer_id,
+                            addrs: addresses,
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect()
     }
 }

--- a/nomos-libp2p/src/behaviour/kademlia/behaviour_ext.rs
+++ b/nomos-libp2p/src/behaviour/kademlia/behaviour_ext.rs
@@ -36,13 +36,8 @@ impl Behaviour {
     }
 
     pub(crate) fn kademlia_discovered_peers(&mut self) -> Vec<PeerInfo> {
-        let Some(kademlia) = self.kademlia.as_mut() else {
-            tracing::error!("kademlia is not enabled");
-            return Vec::new();
-        };
-
         // get all buckets and in each buket, peers with addresses
-        kademlia
+        self.kademlia
             .kbuckets()
             .flat_map(|bucket| {
                 bucket

--- a/nomos-libp2p/src/behaviour/kademlia/swarm_ext.rs
+++ b/nomos-libp2p/src/behaviour/kademlia/swarm_ext.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use libp2p::{kad::QueryId, Multiaddr, PeerId, StreamProtocol};
+use libp2p::{
+    kad::{PeerInfo, QueryId},
+    Multiaddr, PeerId, StreamProtocol,
+};
 
 use crate::Swarm;
 
@@ -23,5 +26,9 @@ impl Swarm {
 
     pub fn kademlia_routing_table_dump(&mut self) -> HashMap<u32, Vec<PeerId>> {
         self.swarm.behaviour_mut().kademlia_routing_table_dump()
+    }
+
+    pub fn kademlia_discovered_peers(&mut self) -> Vec<PeerInfo> {
+        self.swarm.behaviour_mut().kademlia_discovered_peers()
     }
 }

--- a/nomos-services/chain-service/Cargo.toml
+++ b/nomos-services/chain-service/Cargo.toml
@@ -24,6 +24,7 @@ nomos-storage          = { workspace = true }
 nomos-time             = { workspace = true }
 nomos_proof_statements = { workspace = true }
 overwatch              = { workspace = true }
+rand                   = "0.8"
 risc0-zkvm             = { workspace = true }
 serde                  = { version = "1", features = ["derive"] }
 serde_with             = { workspace = true }

--- a/nomos-services/chain-service/src/network/adapters/libp2p.rs
+++ b/nomos-services/chain-service/src/network/adapters/libp2p.rs
@@ -1,10 +1,13 @@
-use std::{collections::HashSet, marker::PhantomData};
+use std::{collections::HashSet, fmt::Debug, hash::Hash, marker::PhantomData};
 
 use cryptarchia_sync::GetTipResponse;
 use futures::TryStreamExt as _;
 use nomos_core::{block::Block, header::HeaderId, wire};
 use nomos_network::{
-    backends::libp2p::{ChainSyncCommand, Command, Libp2p, PeerId, PubSubCommand::Subscribe},
+    backends::libp2p::{
+        ChainSyncCommand, Command, DiscoveryCommand, Libp2p, NetworkCommand, PeerId,
+        PubSubCommand::Subscribe,
+    },
     message::{ChainSyncEvent, NetworkMsg},
     NetworkService,
 };
@@ -12,14 +15,18 @@ use overwatch::{
     services::{relay::OutboundRelay, ServiceData},
     DynError,
 };
+use rand::{seq::index::sample, thread_rng};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::sync::oneshot;
 use tokio_stream::{wrappers::errors::BroadcastStreamRecvError, StreamExt as _};
+use tracing::debug;
 
 use crate::{
     messages::NetworkMessage,
     network::{BoxedStream, NetworkAdapter},
 };
+
+const MAX_PEERS_TO_TRY_FOR_ORPHAN_DOWNLOAD: usize = 3;
 
 type Relay<T, RuntimeServiceId> =
     OutboundRelay<<NetworkService<T, RuntimeServiceId> as ServiceData>::Message>;
@@ -55,6 +62,45 @@ where
         {
             tracing::error!("error subscribing to {topic}: {e}");
         };
+    }
+
+    async fn get_connected_peers(
+        relay: &Relay<Libp2p, RuntimeServiceId>,
+    ) -> Result<HashSet<PeerId>, DynError> {
+        let (reply_sender, receiver) = oneshot::channel();
+        if let Err((e, _)) = relay
+            .send(NetworkMsg::Process(Command::Network(
+                NetworkCommand::ConnectedPeers {
+                    reply: reply_sender,
+                },
+            )))
+            .await
+        {
+            return Err(Box::new(e));
+        }
+
+        let connected_peers = receiver.await.map_err(|e| Box::new(e) as DynError)?;
+        Ok(connected_peers)
+    }
+
+    async fn get_discovered_peers(
+        relay: &Relay<Libp2p, RuntimeServiceId>,
+    ) -> Result<HashSet<PeerId>, DynError> {
+        let (reply_sender, receiver) = oneshot::channel();
+        if let Err((e, _)) = relay
+            .send(NetworkMsg::Process(Command::Discovery(
+                DiscoveryCommand::GetDiscoveredPeers {
+                    reply: reply_sender,
+                },
+            )))
+            .await
+        {
+            return Err(Box::new(e));
+        }
+
+        let discovered_peers = receiver.await.map_err(|e| Box::new(e) as DynError)?;
+
+        Ok(discovered_peers)
     }
 }
 
@@ -183,5 +229,148 @@ where
         });
 
         Ok(Box::new(stream))
+    }
+
+    /// Attempts to open a stream of blocks from a locally known block to the
+    /// orphan block.
+    async fn request_missing_blocks_for_orphan(
+        &self,
+        orphan_block: HeaderId,
+        local_tip: HeaderId,
+        latest_immutable_block: HeaderId,
+        additional_blocks: HashSet<HeaderId>,
+    ) -> Result<BoxedStream<Result<Block<Self::Tx, Self::BlobCertificate>, DynError>>, DynError>
+    {
+        let connected_peers = Self::get_connected_peers(&self.network_relay).await?;
+
+        // All peers we know about, including those that are not connected.
+        let discovered_peers = Self::get_discovered_peers(&self.network_relay).await?;
+
+        let peers_to_request = choose_peers_to_request_download(
+            connected_peers,
+            &discovered_peers,
+            MAX_PEERS_TO_TRY_FOR_ORPHAN_DOWNLOAD,
+        );
+
+        for peer in peers_to_request {
+            match self
+                .request_blocks_from_peer(
+                    peer,
+                    // as the target block
+                    orphan_block,
+                    local_tip,
+                    latest_immutable_block,
+                    additional_blocks.clone(),
+                )
+                .await
+            {
+                Ok(stream) => {
+                    debug!("Requested orphan parents from peer: {peer}");
+                    return Ok(stream);
+                }
+                Err(err) => {
+                    tracing::warn!("Failed to request orphan parents from peer {peer}: {err}");
+                }
+            }
+        }
+
+        Err("Failed to request orphan parents from any peer".into())
+    }
+}
+
+/// Selects up to `MAX_PEERS_TO_TRY_FOR_ORPHAN_DOWNLOAD` peers to request
+/// downloads from, preferring discovered peers that are not currently
+/// connected. If not enough, fills from connected peers.
+///
+/// Returned the list of `PeerId` with discovered peers appearing before
+/// connected ones(if any).
+fn choose_peers_to_request_download<PeerId>(
+    connected_peers: HashSet<PeerId>,
+    discovered_peers: &HashSet<PeerId>,
+    max: usize,
+) -> Vec<PeerId>
+where
+    PeerId: Clone + Eq + Hash + Copy + Debug,
+{
+    let discovered_only: Vec<_> = discovered_peers
+        .difference(&connected_peers)
+        .copied()
+        .collect();
+
+    // Use Vec to keep not connected in front
+    let mut selected = Vec::new();
+
+    let discovered_only_max_to_use = discovered_only.len().min(max);
+
+    if discovered_only_max_to_use > 0 {
+        let indexes = sample(
+            &mut thread_rng(),
+            discovered_only.len(),
+            discovered_only_max_to_use,
+        );
+        selected.extend(indexes.into_iter().map(|i| discovered_only[i]));
+    }
+
+    let remaining = max.saturating_sub(selected.len());
+    let remaining_available = remaining.min(connected_peers.len());
+
+    if remaining_available > 0 {
+        let connected_vec: Vec<_> = connected_peers.into_iter().collect();
+
+        let indexes = sample(&mut thread_rng(), connected_vec.len(), remaining_available);
+        selected.extend(indexes.into_iter().map(|i| connected_vec[i]));
+    }
+
+    selected
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    const MAX: usize = MAX_PEERS_TO_TRY_FOR_ORPHAN_DOWNLOAD;
+
+    #[test]
+    fn returns_only_discovered_peers() {
+        let connected = HashSet::from_iter(vec![[1; 32], [2; 32]]);
+        let discovered = HashSet::from_iter(vec![[3; 32], [4; 32], [5; 32]]);
+
+        let result = choose_peers_to_request_download(connected, &discovered, MAX);
+
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&[3; 32]));
+        assert!(result.contains(&[4; 32]));
+        assert!(result.contains(&[5; 32]));
+    }
+
+    #[test]
+    fn returns_all_connected_peers_if_no_discovered_peers() {
+        let connected = HashSet::from_iter(vec![[1; 32], [2; 32], [3; 32]]);
+        let discovered = HashSet::new();
+
+        let result = choose_peers_to_request_download(connected.clone(), &discovered, MAX);
+
+        assert_eq!(result.len(), connected.len());
+    }
+
+    #[test]
+    fn includes_connected_peers_if_discovered_peers_are_not_enough() {
+        let connected = HashSet::from_iter(vec![[1; 32], [2; 32], [3; 32]]);
+        let discovered = HashSet::from_iter(vec![[4; 32]]);
+
+        let result = choose_peers_to_request_download(connected, &discovered, MAX);
+
+        assert_eq!(result.len(), MAX);
+        assert!(result.contains(&[4; 32]));
+    }
+
+    #[test]
+    fn limits_number_of_peers_to_max_attempts() {
+        let connected = (0..=MAX).map(|id| [id; 32]).collect::<HashSet<_>>();
+        let discovered = HashSet::new();
+
+        let result = choose_peers_to_request_download(connected, &discovered, MAX);
+        assert_eq!(result.len(), MAX);
     }
 }

--- a/nomos-services/chain-service/src/network/adapters/libp2p.rs
+++ b/nomos-services/chain-service/src/network/adapters/libp2p.rs
@@ -232,15 +232,14 @@ where
     }
 
     /// Attempts to open a stream of blocks from a locally known block to the
-    /// orphan block.
-    async fn request_missing_blocks_for_orphan(
+    /// target_block block.
+    async fn request_blocks_from_peers(
         &self,
-        orphan_block: HeaderId,
+        target_block: HeaderId,
         local_tip: HeaderId,
         latest_immutable_block: HeaderId,
         additional_blocks: HashSet<HeaderId>,
-    ) -> Result<BoxedStream<Result<Block<Self::Tx, Self::BlobCertificate>, DynError>>, DynError>
-    {
+    ) -> Result<BoxedStream<Result<Self::Block, DynError>>, DynError> {
         let connected_peers = Self::get_connected_peers(&self.network_relay).await?;
 
         // All peers we know about, including those that are not connected.
@@ -257,7 +256,7 @@ where
                 .request_blocks_from_peer(
                     peer,
                     // as the target block
-                    orphan_block,
+                    target_block,
                     local_tip,
                     latest_immutable_block,
                     additional_blocks.clone(),

--- a/nomos-services/chain-service/src/network/mod.rs
+++ b/nomos-services/chain-service/src/network/mod.rs
@@ -41,7 +41,7 @@ pub trait NetworkAdapter<RuntimeServiceId> {
         additional_blocks: HashSet<HeaderId>,
     ) -> Result<BoxedStream<Result<Self::Block, DynError>>, DynError>;
 
-    async fn request_missing_blocks_for_orphan(
+    async fn request_blocks_from_peers(
         &self,
         target_block: HeaderId,
         local_tip: HeaderId,

--- a/nomos-services/chain-service/src/network/mod.rs
+++ b/nomos-services/chain-service/src/network/mod.rs
@@ -40,4 +40,12 @@ pub trait NetworkAdapter<RuntimeServiceId> {
         latest_immutable_block: HeaderId,
         additional_blocks: HashSet<HeaderId>,
     ) -> Result<BoxedStream<Result<Self::Block, DynError>>, DynError>;
+
+    async fn request_missing_blocks_for_orphan(
+        &self,
+        target_block: HeaderId,
+        local_tip: HeaderId,
+        latest_immutable_block: HeaderId,
+        additional_blocks: HashSet<HeaderId>,
+    ) -> Result<BoxedStream<Result<Self::Block, DynError>>, DynError>;
 }

--- a/nomos-services/network/src/backends/libp2p/command.rs
+++ b/nomos-services/network/src/backends/libp2p/command.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use nomos_libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
@@ -8,7 +10,12 @@ pub use crate::backends::libp2p::swarm::{ChainSyncCommand, DiscoveryCommand, Pub
 #[non_exhaustive]
 pub enum NetworkCommand {
     Connect(Dial),
-    Info { reply: oneshot::Sender<Libp2pInfo> },
+    Info {
+        reply: oneshot::Sender<Libp2pInfo>,
+    },
+    ConnectedPeers {
+        reply: oneshot::Sender<HashSet<PeerId>>,
+    },
 }
 
 #[derive(Debug)]

--- a/nomos-services/network/src/backends/libp2p/swarm/mod.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm/mod.rs
@@ -190,6 +190,10 @@ impl SwarmHandler {
                 };
                 log_error!(reply.send(info));
             }
+            NetworkCommand::ConnectedPeers { reply } => {
+                let connected_peers = self.swarm.swarm().connected_peers().copied().collect();
+                log_error!(reply.send(connected_peers));
+            }
         }
     }
 


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adds functionality to consensus service network adapter to request downloading missing blocks in order to connect an orphan block with local chain. 

It chooses a random peer from all discovered peers that are not connected, and falls back to connected peers if such peers don’t exist. 

Note: This PR not implementing the actual logic to trigger downloading missing blocks for an orphan block and adding them to the block tree.

## 2. Does the code have enough context to be clearly understood?

Yes. Please also see [Bootstrapping spec](https://www.notion.so/Cryptarchia-v1-Bootstrapping-Synchronization-1fd261aa09df81ac94b5fb6a4eff32a6)

## 3. Who are the specification authors and who is accountable for this PR?

@andrussal 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.