### PR TITLE
feat(blend): add support for session clock in blend swarm

### DIFF
--- a/nodes/nomos-executor/executor/src/lib.rs
+++ b/nodes/nomos-executor/executor/src/lib.rs
@@ -29,6 +29,7 @@ use nomos_da_verifier::{
     network::adapters::executor::Libp2pAdapter as VerifierNetworkAdapter,
     storage::adapters::rocksdb::RocksAdapter as VerifierStorageAdapter,
 };
+use nomos_libp2p::PeerId;
 use nomos_mempool::backend::mockpool::MockPool;
 #[cfg(feature = "tracing")]
 use nomos_node::Tracing;
@@ -48,6 +49,7 @@ pub(crate) type NetworkService = nomos_network::NetworkService<NetworkBackend, R
 
 pub(crate) type BlendService = nomos_blend_service::BlendService<
     BlendBackend,
+    PeerId,
     BlendNetworkAdapter<RuntimeServiceId>,
     RuntimeServiceId,
 >;

--- a/nodes/nomos-node/node/src/lib.rs
+++ b/nodes/nomos-node/node/src/lib.rs
@@ -32,6 +32,7 @@ use nomos_da_verifier::{
     network::adapters::validator::Libp2pAdapter as VerifierNetworkAdapter,
     storage::adapters::rocksdb::RocksAdapter as VerifierStorageAdapter,
 };
+use nomos_libp2p::PeerId;
 pub use nomos_mempool::{
     da::settings::DaMempoolSettings,
     network::adapters::libp2p::{
@@ -88,6 +89,7 @@ pub(crate) type NetworkService = nomos_network::NetworkService<NetworkBackend, R
 
 pub(crate) type BlendService = nomos_blend_service::BlendService<
     BlendBackend,
+    PeerId,
     BlendNetworkAdapter<RuntimeServiceId>,
     RuntimeServiceId,
 >;

--- a/nomos-services/blend/src/backends/libp2p/mod.rs
+++ b/nomos-services/blend/src/backends/libp2p/mod.rs
@@ -37,14 +37,13 @@ pub struct Libp2pBlendBackend {
 const CHANNEL_SIZE: usize = 64;
 
 #[async_trait]
-impl<RuntimeServiceId> BlendBackend<RuntimeServiceId> for Libp2pBlendBackend {
+impl<RuntimeServiceId> BlendBackend<PeerId, RuntimeServiceId> for Libp2pBlendBackend {
     type Settings = Libp2pBlendBackendSettings;
-    type NodeId = PeerId;
 
     fn new<Rng>(
-        config: BlendConfig<Self::Settings, Self::NodeId>,
+        config: BlendConfig<Self::Settings, PeerId>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        membership: Membership<Self::NodeId>,
+        session_stream: Pin<Box<dyn Stream<Item = Membership<PeerId>> + Send>>,
         rng: Rng,
     ) -> Self
     where
@@ -55,7 +54,7 @@ impl<RuntimeServiceId> BlendBackend<RuntimeServiceId> for Libp2pBlendBackend {
 
         let swarm = BlendSwarm::new(
             config,
-            membership,
+            session_stream,
             rng,
             swarm_message_receiver,
             incoming_message_sender.clone(),

--- a/nomos-services/blend/src/backends/libp2p/swarm.rs
+++ b/nomos-services/blend/src/backends/libp2p/swarm.rs
@@ -32,7 +32,6 @@ pub(super) struct BlendSwarm<SessionStream, Rng> {
 
 impl<SessionStream, Rng> BlendSwarm<SessionStream, Rng>
 where
-    SessionStream: Stream<Item = Membership<PeerId>>,
     Rng: RngCore,
 {
     pub(super) fn new(

--- a/nomos-services/blend/src/backends/libp2p/swarm.rs
+++ b/nomos-services/blend/src/backends/libp2p/swarm.rs
@@ -128,6 +128,7 @@ impl<SessionStream, Rng> BlendSwarm<SessionStream, Rng> {
 impl<SessionStream, Rng> BlendSwarm<SessionStream, Rng>
 where
     Rng: RngCore,
+    SessionStream: Stream<Item = Membership<PeerId>> + Unpin,
 {
     pub(super) async fn run(mut self) {
         loop {
@@ -137,6 +138,10 @@ where
                 }
                 Some(event) = self.swarm.next() => {
                     self.handle_event(event);
+                }
+                Some(new_session_info) = self.session_stream.next() => {
+                    self.latest_session_info = new_session_info;
+                    // TODO: Perform the session transition logic
                 }
             }
         }

--- a/nomos-services/blend/src/backends/libp2p/swarm.rs
+++ b/nomos-services/blend/src/backends/libp2p/swarm.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, time::Duration};
 
-use futures::StreamExt as _;
+use futures::{Stream, StreamExt as _};
 use libp2p::{identity::Keypair, PeerId, Swarm, SwarmBuilder};
 use nomos_blend_scheduling::membership::Membership;
 use nomos_libp2p::{ed25519, SwarmEvent};
@@ -20,27 +20,29 @@ pub enum BlendSwarmMessage {
     Publish(Vec<u8>),
 }
 
-pub(super) struct BlendSwarm<Rng> {
+pub(super) struct BlendSwarm<SessionStream, Rng> {
     swarm: Swarm<BlendBehaviour>,
     swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage>,
     incoming_message_sender: broadcast::Sender<Vec<u8>>,
-    // TODO: Instead of holding the membership, we just want a way to get the list of addresses.
-    membership: Membership<PeerId>,
+    session_stream: SessionStream,
+    latest_session_info: Membership<PeerId>,
     rng: Rng,
     peering_degree: usize,
 }
 
-impl<Rng> BlendSwarm<Rng>
+impl<SessionStream, Rng> BlendSwarm<SessionStream, Rng>
 where
+    SessionStream: Stream<Item = Membership<PeerId>>,
     Rng: RngCore,
 {
     pub(super) fn new(
         config: BlendConfig<Libp2pBlendBackendSettings, PeerId>,
-        membership: Membership<PeerId>,
+        session_stream: SessionStream,
         mut rng: Rng,
         swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage>,
         incoming_message_sender: broadcast::Sender<Vec<u8>>,
     ) -> Self {
+        let membership = config.membership();
         let keypair = Keypair::from(ed25519::Keypair::from(config.backend.node_key.clone()));
         let mut swarm = SwarmBuilder::with_existing_identity(keypair)
             .with_tokio()
@@ -74,14 +76,15 @@ where
             swarm,
             swarm_messages_receiver,
             incoming_message_sender,
-            membership,
+            session_stream,
+            latest_session_info: membership,
             rng,
             peering_degree: config.backend.peering_degree,
         }
     }
 }
 
-impl<Rng> BlendSwarm<Rng> {
+impl<SessionStream, Rng> BlendSwarm<SessionStream, Rng> {
     fn handle_swarm_message(&mut self, msg: BlendSwarmMessage) {
         match msg {
             BlendSwarmMessage::Publish(msg) => {
@@ -122,7 +125,7 @@ impl<Rng> BlendSwarm<Rng> {
     }
 }
 
-impl<Rng> BlendSwarm<Rng>
+impl<SessionStream, Rng> BlendSwarm<SessionStream, Rng>
 where
     Rng: RngCore,
 {
@@ -221,7 +224,7 @@ where
             .chain(self.swarm.behaviour().blocked_peers.blocked_peers())
             .copied()
             .collect();
-        self.membership
+        self.latest_session_info
             .filter_and_choose_remote_nodes(&mut self.rng, amount, &exclude_peers)
             .iter()
             .for_each(|peer| {

--- a/nomos-services/blend/src/backends/mod.rs
+++ b/nomos-services/blend/src/backends/mod.rs
@@ -12,14 +12,13 @@ use crate::BlendConfig;
 
 /// A trait for blend backends that send messages to the blend network.
 #[async_trait::async_trait]
-pub trait BlendBackend<RuntimeServiceId> {
+pub trait BlendBackend<NodeId, RuntimeServiceId> {
     type Settings: Clone + Debug + Send + Sync + 'static;
-    type NodeId: Clone + Debug + Send + Sync + 'static;
 
     fn new<R>(
-        service_config: BlendConfig<Self::Settings, Self::NodeId>,
+        service_config: BlendConfig<Self::Settings, NodeId>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        membership: Membership<Self::NodeId>,
+        session_stream: Pin<Box<dyn Stream<Item = Membership<NodeId>> + Send>>,
         rng: R,
     ) -> Self
     where

--- a/nomos-services/blend/src/lib.rs
+++ b/nomos-services/blend/src/lib.rs
@@ -84,8 +84,8 @@ where
         + Clone
         + Debug
         + Display
-        + Send
         + Sync
+        + Send
         + 'static,
 {
     fn init(

--- a/nomos-services/blend/src/lib.rs
+++ b/nomos-services/blend/src/lib.rs
@@ -6,7 +6,6 @@ pub mod settings;
 use std::{
     fmt::{Debug, Display},
     future::Future,
-    hash::Hash,
     time::Duration,
 };
 
@@ -34,6 +33,8 @@ use rand::{seq::SliceRandom as _, RngCore, SeedableRng as _};
 use rand_chacha::ChaCha12Rng;
 use serde::Deserialize;
 use services_utils::wait_until_services_are_ready;
+use tokio::time::interval;
+use tokio_stream::wrappers::IntervalStream;
 
 use crate::{
     message::{NetworkMessage, ProcessedMessage, ServiceMessage},
@@ -49,42 +50,42 @@ const LOG_TARGET: &str = "blend::service";
 /// independent of each other. For example, the blend backend can use the
 /// libp2p network stack, while the network adapter can use the other network
 /// backend.
-pub struct BlendService<Backend, Network, RuntimeServiceId>
+pub struct BlendService<Backend, NodeId, Network, RuntimeServiceId>
 where
-    Backend: BlendBackend<RuntimeServiceId>,
+    Backend: BlendBackend<NodeId, RuntimeServiceId>,
     Network: NetworkAdapter<RuntimeServiceId>,
 {
     backend: Backend,
     service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
-    membership: Membership<Backend::NodeId>,
+    membership: Membership<NodeId>,
 }
 
-impl<Backend, Network, RuntimeServiceId> ServiceData
-    for BlendService<Backend, Network, RuntimeServiceId>
+impl<Backend, NodeId, Network, RuntimeServiceId> ServiceData
+    for BlendService<Backend, NodeId, Network, RuntimeServiceId>
 where
-    Backend: BlendBackend<RuntimeServiceId>,
+    Backend: BlendBackend<NodeId, RuntimeServiceId>,
     Network: NetworkAdapter<RuntimeServiceId>,
 {
-    type Settings = BlendConfig<Backend::Settings, Backend::NodeId>;
+    type Settings = BlendConfig<Backend::Settings, NodeId>;
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State>;
     type Message = ServiceMessage<Network::BroadcastSettings>;
 }
 
 #[async_trait]
-impl<Backend, Network, RuntimeServiceId> ServiceCore<RuntimeServiceId>
-    for BlendService<Backend, Network, RuntimeServiceId>
+impl<Backend, NodeId, Network, RuntimeServiceId> ServiceCore<RuntimeServiceId>
+    for BlendService<Backend, NodeId, Network, RuntimeServiceId>
 where
-    Backend: BlendBackend<RuntimeServiceId> + Send + Sync + 'static,
-    Backend::NodeId: Hash + Eq + Unpin,
-    Network: NetworkAdapter<RuntimeServiceId, BroadcastSettings: Unpin> + Send + Sync + 'static,
+    Backend: BlendBackend<NodeId, RuntimeServiceId> + Send + Sync,
+    NodeId: Clone + Send + Sync + 'static,
+    Network: NetworkAdapter<RuntimeServiceId, BroadcastSettings: Unpin> + Send + Sync,
     RuntimeServiceId: AsServiceId<NetworkService<Network::Backend, RuntimeServiceId>>
         + AsServiceId<Self>
         + Clone
         + Debug
         + Display
-        + Sync
         + Send
+        + Sync
         + 'static,
 {
     fn init(
@@ -93,11 +94,15 @@ where
     ) -> Result<Self, overwatch::DynError> {
         let settings_reader = service_resources_handle.settings_handle.notifier();
         let blend_config = settings_reader.get_updated_settings();
+        let membership = blend_config.membership();
         Ok(Self {
-            backend: <Backend as BlendBackend<RuntimeServiceId>>::new(
+            backend: <Backend as BlendBackend<NodeId, RuntimeServiceId>>::new(
                 settings_reader.get_updated_settings(),
                 service_resources_handle.overwatch_handle.clone(),
-                blend_config.membership(),
+                Box::pin(
+                    IntervalStream::new(interval(blend_config.time.session_duration()))
+                        .map(move |_| membership.clone()),
+                ),
                 ChaCha12Rng::from_entropy(),
             ),
             service_resources_handle,
@@ -206,7 +211,7 @@ async fn handle_local_data_message<
 ) where
     NodeId: Send,
     Rng: RngCore + Send,
-    Backend: BlendBackend<RuntimeServiceId> + Sync,
+    Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync,
 {
     let Ok(wrapped_message) = cryptographic_processor
         .encapsulate_data_message(&local_data_message)
@@ -282,7 +287,7 @@ async fn handle_release_round<NodeId, Rng, Backend, NetAdapter, RuntimeServiceId
     network_adapter: &NetAdapter,
 ) where
     Rng: RngCore + Send,
-    Backend: BlendBackend<RuntimeServiceId> + Sync,
+    Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync,
     NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
 {
     let mut processed_messages_relay_futures = processed_messages
@@ -318,9 +323,10 @@ async fn handle_release_round<NodeId, Rng, Backend, NetAdapter, RuntimeServiceId
     tracing::debug!(target: LOG_TARGET, "Sent out {total_message_count} processed and/or cover messages at this release window.");
 }
 
-impl<Backend, Network, RuntimeServiceId> Drop for BlendService<Backend, Network, RuntimeServiceId>
+impl<Backend, NodeId, Network, RuntimeServiceId> Drop
+    for BlendService<Backend, NodeId, Network, RuntimeServiceId>
 where
-    Backend: BlendBackend<RuntimeServiceId>,
+    Backend: BlendBackend<NodeId, RuntimeServiceId>,
     Network: NetworkAdapter<RuntimeServiceId>,
 {
     fn drop(&mut self) {

--- a/nomos-services/blend/src/settings.rs
+++ b/nomos-services/blend/src/settings.rs
@@ -95,17 +95,17 @@ impl TimingSettings {
     }
 }
 
-impl<BackendSettings, BackendNodeId> BlendConfig<BackendSettings, BackendNodeId>
+impl<BackendSettings, NodeId> BlendConfig<BackendSettings, NodeId>
 where
-    BackendNodeId: Clone,
+    NodeId: Clone,
 {
-    pub(super) fn membership(&self) -> Membership<BackendNodeId> {
+    pub(super) fn membership(&self) -> Membership<NodeId> {
         let local_signing_pubkey = self.crypto.signing_private_key.public_key();
         Membership::new(self.membership.clone(), &local_signing_pubkey)
     }
 }
 
-impl<BackendSettings, BackendNodeId> BlendConfig<BackendSettings, BackendNodeId> {
+impl<BackendSettings, NodeId> BlendConfig<BackendSettings, NodeId> {
     pub(super) fn session_stream(&self) -> impl Stream<Item = SessionInfo> {
         let membership_size = self.membership.len() + 1;
         let static_quota_for_membership =

--- a/nomos-services/blend/src/settings.rs
+++ b/nomos-services/blend/src/settings.rs
@@ -12,12 +12,12 @@ use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct BlendConfig<BackendSettings, BackendNodeId> {
+pub struct BlendConfig<BackendSettings, NodeId> {
     pub backend: BackendSettings,
     pub crypto: CryptographicProcessorSettings,
     pub scheduler: SchedulerSettingsExt,
     pub time: TimingSettings,
-    pub membership: Vec<Node<BackendNodeId>>,
+    pub membership: Vec<Node<NodeId>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -84,11 +84,13 @@ pub struct TimingSettings {
 }
 
 impl TimingSettings {
-    const fn session_duration(&self) -> Duration {
+    #[must_use]
+    pub const fn session_duration(&self) -> Duration {
         Duration::from_secs(self.rounds_per_session.get() * self.round_duration.as_secs())
     }
 
-    fn intervals_per_session(&self) -> NonZeroU64 {
+    #[must_use]
+    pub fn intervals_per_session(&self) -> NonZeroU64 {
         NonZeroU64::try_from(self.rounds_per_session.get() / self.rounds_per_interval.get()).expect("Obtained `0` when calculating the number of intervals per session, which is not allowed.")
     }
 }

--- a/nomos-services/chain-service/src/blend/adapters/libp2p.rs
+++ b/nomos-services/chain-service/src/blend/adapters/libp2p.rs
@@ -5,6 +5,7 @@ use nomos_blend_service::{
     BlendService,
 };
 use nomos_core::{block::Block, wire};
+use nomos_network::backends::libp2p::PeerId;
 use overwatch::services::{relay::OutboundRelay, ServiceData};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -20,7 +21,7 @@ where
 {
     settings: LibP2pAdapterSettings<Network::BroadcastSettings>,
     blend_relay: OutboundRelay<
-        <BlendService<Libp2pBlendBackend, Network, RuntimeServiceId> as ServiceData>::Message,
+        <BlendService<Libp2pBlendBackend, PeerId, Network, RuntimeServiceId> as ServiceData>::Message,
     >,
     _tx: PhantomData<Tx>,
     _blob_cert: PhantomData<BlobCert>,
@@ -40,11 +41,12 @@ where
     type Network = Network;
     type Tx = Tx;
     type BlobCertificate = BlobCert;
+    type NodeId = PeerId;
 
     async fn new(
         settings: Self::Settings,
         blend_relay: OutboundRelay<
-            <BlendService<Self::Backend, Self::Network, RuntimeServiceId> as ServiceData>::Message,
+            <BlendService<Self::Backend, Self::NodeId, Self::Network, RuntimeServiceId> as ServiceData>::Message,
         >,
     ) -> Self {
         // this wait seems to be helpful in some cases since we give the time

--- a/nomos-services/chain-service/src/blend/mod.rs
+++ b/nomos-services/chain-service/src/blend/mod.rs
@@ -8,14 +8,16 @@ use serde::{de::DeserializeOwned, Serialize};
 #[async_trait::async_trait]
 pub trait BlendAdapter<RuntimeServiceId> {
     type Settings: Clone + 'static;
-    type Backend: BlendBackend<RuntimeServiceId> + 'static;
+    type Backend: BlendBackend<Self::NodeId, RuntimeServiceId> + 'static;
     type Network: NetworkAdapter<RuntimeServiceId> + 'static;
     type Tx: Serialize + DeserializeOwned + Clone + Eq + 'static;
     type BlobCertificate: Serialize + DeserializeOwned + Clone + Eq + 'static;
+    type NodeId;
+
     async fn new(
         settings: Self::Settings,
         blend_relay: OutboundRelay<
-            <BlendService<Self::Backend, Self::Network, RuntimeServiceId> as ServiceData>::Message,
+            <BlendService<Self::Backend, Self::NodeId, Self::Network, RuntimeServiceId> as ServiceData>::Message,
         >,
     ) -> Self;
     async fn blend(&self, block: Block<Self::Tx, Self::BlobCertificate>);

--- a/nomos-services/chain-service/src/lib.rs
+++ b/nomos-services/chain-service/src/lib.rs
@@ -475,7 +475,14 @@ where
         + 'static
         + AsServiceId<Self>
         + AsServiceId<NetworkService<NetAdapter::Backend, RuntimeServiceId>>
-        + AsServiceId<BlendService<BlendAdapter::Backend, BlendAdapter::Network, RuntimeServiceId>>
+        + AsServiceId<
+            BlendService<
+                BlendAdapter::Backend,
+                BlendAdapter::NodeId,
+                BlendAdapter::Network,
+                RuntimeServiceId,
+            >,
+        >
         + AsServiceId<TxMempoolService<ClPoolAdapter, ClPool, RuntimeServiceId>>
         + AsServiceId<
             DaMempoolService<
@@ -607,7 +614,7 @@ where
             &self.service_resources_handle.overwatch_handle,
             Some(Duration::from_secs(60)),
             NetworkService<_, _>,
-            BlendService<_, _, _>,
+            BlendService<_, _, _, _>,
             TxMempoolService<_, _, _>,
             DaMempoolService<_, _, _, _, _, _, _, _, _, _, _>,
             DaSamplingService<_, _, _, _, _, _, _, _, _>,

--- a/nomos-services/chain-service/src/relays.rs
+++ b/nomos-services/chain-service/src/relays.rs
@@ -258,7 +258,12 @@ where
             + 'static
             + AsServiceId<NetworkService<NetworkAdapter::Backend, RuntimeServiceId>>
             + AsServiceId<
-                BlendService<BlendAdapter::Backend, BlendAdapter::Network, RuntimeServiceId>,
+                BlendService<
+                    BlendAdapter::Backend,
+                    BlendAdapter::NodeId,
+                    BlendAdapter::Network,
+                    RuntimeServiceId,
+                >,
             >
             + AsServiceId<TxMempoolService<ClPoolAdapter, ClPool, RuntimeServiceId>>
             + AsServiceId<
@@ -300,7 +305,7 @@ where
 
         let blend_relay = service_resources_handle
             .overwatch_handle
-            .relay::<BlendService<_, _, _>>()
+            .relay::<BlendService<_, _, _, _>>()
             .await
             .expect(
                 "Relay connection with nomos_blend_service::BlendService should


### PR DESCRIPTION
## 1. What does this PR implement?

This PR changes the interface between the Blend service and the Blend swarm to allow the service to pass a session stream to the swarm. No logic is yet executed upon session change, besides updating the internal membership (which is statically configured at the moment).

The change of `NodeId` from an associated type to a generic was required else we would not be able to create a stream yielding a `Membership<NodeId>` from outside the backend if we don't know the concrete type of `NodeId` in the service. So we need to change the logic for the `NodeId` to be injected all the way down from the node binary, which knows all the concrete types used. 

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
