### PR TITLE
chore(rand): Refactor fisher yates to be generic over rng

### DIFF
--- a/nomos-utils/Cargo.toml
+++ b/nomos-utils/Cargo.toml
@@ -8,19 +8,19 @@ version = "0.1.0"
 workspace = true
 
 [dependencies]
-blake2      = { version = "0.10", optional = true }
-const-hex   = "1"
-humantime   = { version = "2.1", optional = true }
-rand        = "0.9"
-rand_chacha = "0.9"
-serde       = { version = "1.0", optional = true, features = ["derive"] }
-serde_with  = { workspace = true, optional = true }
-time        = { version = "0.3", optional = true, features = ["serde-human-readable"] }
+blake2     = { version = "0.10", optional = true }
+const-hex  = "1"
+humantime  = { version = "2.1", optional = true }
+rand       = "0.9"
+serde      = { version = "1.0", optional = true, features = ["derive"] }
+serde_with = { workspace = true, optional = true }
+time       = { version = "0.3", optional = true, features = ["serde-human-readable"] }
 
 [features]
 rng  = ["blake2"]
 time = ["dep:humantime", "dep:serde_with", "dep:time", "serde"]
 
 [dev-dependencies]
-nistrs     = "0.1.2"
-serde_json = "1.0"
+nistrs      = "0.1.2"
+rand_chacha = "0.9"
+serde_json  = "1.0"

--- a/nomos-utils/src/fisheryates.rs
+++ b/nomos-utils/src/fisheryates.rs
@@ -1,19 +1,10 @@
-use rand::{Rng as _, SeedableRng as _};
-use rand_chacha::ChaCha20Rng;
+use rand::{Rng as _, RngCore};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct FisherYatesShuffle {
-    pub entropy: [u8; 32],
-}
+pub struct FisherYates;
 
-impl FisherYatesShuffle {
-    #[must_use]
-    pub const fn new(entropy: [u8; 32]) -> Self {
-        Self { entropy }
-    }
-
-    pub fn shuffle<T: Clone>(elements: &mut [T], entropy: [u8; 32]) {
-        let mut rng = ChaCha20Rng::from_seed(entropy);
+impl FisherYates {
+    pub fn shuffle<R: RngCore, T: Clone>(elements: &mut [T], rng: &mut R) {
         // Implementation of fisher yates shuffling
         // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
         for i in (1..elements.len()).rev() {


### PR DESCRIPTION
## 1. What does this PR implement?

Refactore fisher yates shuffling algorithm so it is generic over rng instead of using a custom seed over chacha.

## 2. Does the code have enough context to be clearly understood?

Its really simple


## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
