### PR TITLE
feat(da): use da-network get commitments from sampling 

### DIFF
--- a/nodes/nomos-executor/executor/src/lib.rs
+++ b/nodes/nomos-executor/executor/src/lib.rs
@@ -16,9 +16,7 @@ use nomos_da_dispersal::{
     backend::kzgrs::DispersalKZGRSBackend,
     DispersalService,
 };
-use nomos_da_network_service::{
-    api::http::HttApiAdapter, backends::libp2p::executor::DaNetworkExecutorBackend,
-};
+use nomos_da_network_service::backends::libp2p::executor::DaNetworkExecutorBackend;
 use nomos_da_sampling::{
     backend::kzgrs::KzgrsSamplingBackend,
     storage::adapters::rocksdb::{
@@ -250,7 +248,7 @@ pub(crate) type ApiService = nomos_api::ApiService<
         >,
         SamplingStorageAdapter<DaShare, Wire, DaStorageConverter>,
         NtpTimeBackend,
-        HttApiAdapter<NomosDaMembership>,
+        DaNetworkApiAdapter,
         ApiStorageAdapter<Wire, RuntimeServiceId>,
         MB16,
     >,

--- a/nodes/nomos-node/node/src/lib.rs
+++ b/nodes/nomos-node/node/src/lib.rs
@@ -18,7 +18,10 @@ pub use nomos_core::{
     wire,
 };
 pub use nomos_da_network_service::backends::libp2p::validator::DaNetworkValidatorBackend;
-use nomos_da_network_service::{api::http::HttApiAdapter, storage::adapters::mock::MockStorage};
+use nomos_da_network_service::{
+    api::http::HttApiAdapter, membership::handler::DaMembershipHandler,
+    storage::adapters::mock::MockStorage,
+};
 use nomos_da_sampling::{
     backend::kzgrs::KzgrsSamplingBackend,
     network::adapters::validator::Libp2pAdapter as SamplingLibp2pAdapter,
@@ -79,7 +82,7 @@ impl StorageSerde for Wire {
 /// Membership used by the DA Network service.
 pub type NomosDaMembership = FillFromNodeList;
 pub type DaMembershipStorage = MockStorage;
-pub type DaNetworkApiAdapter = HttApiAdapter<NomosDaMembership>;
+pub type DaNetworkApiAdapter = HttApiAdapter<DaMembershipHandler<NomosDaMembership>>;
 
 #[cfg(feature = "tracing")]
 pub(crate) type TracingService = Tracing<RuntimeServiceId>;

--- a/nomos-services/data-availability/dispersal/src/adapters/network/libp2p.rs
+++ b/nomos-services/data-availability/dispersal/src/adapters/network/libp2p.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, fmt::Debug, marker::PhantomData, pin::Pin, time::Duration};
 
 use futures::{stream::BoxStream, Stream, StreamExt as _};
-use kzgrs_backend::common::share::DaShare;
+use kzgrs_backend::common::share::{DaShare, DaSharesCommitments};
 use nomos_core::da::BlobId;
 use nomos_da_network_core::{
     protocols::{
@@ -46,7 +46,12 @@ pub struct Libp2pNetworkAdapter<
     ApiAdapter: ApiAdapterTrait,
 {
     outbound_relay: OutboundRelay<
-        DaNetworkMsg<DaNetworkExecutorBackend<Membership>, Membership, RuntimeServiceId>,
+        DaNetworkMsg<
+            DaNetworkExecutorBackend<Membership>,
+            Membership,
+            DaSharesCommitments,
+            RuntimeServiceId,
+        >,
     >,
     _phantom: PhantomData<(
         RuntimeServiceId,

--- a/nomos-services/data-availability/sampling/src/network/adapters/common.rs
+++ b/nomos-services/data-availability/sampling/src/network/adapters/common.rs
@@ -31,7 +31,7 @@ macro_rules! adapter_for {
                     Share = DaShare,
                     BlobId = BlobId,
                     Commitments = DaSharesCommitments,
-                    Membership = Membership,
+                    Membership = DaMembershipHandler<Membership>,
                 > + Clone
                 + Send
                 + Sync

--- a/nomos-services/data-availability/sampling/src/network/adapters/common.rs
+++ b/nomos-services/data-availability/sampling/src/network/adapters/common.rs
@@ -102,7 +102,7 @@ macro_rules! adapter_for {
                     })
                     .await
                     .expect("RequestCommitments message should have been sent");
-                reply_receiver.await.map_err(|_| "Failed to receive commitments reply".into())
+                reply_receiver.await.map_err(DynError::from)
             }
         }
     }

--- a/nomos-services/data-availability/sampling/src/network/adapters/common.rs
+++ b/nomos-services/data-availability/sampling/src/network/adapters/common.rs
@@ -89,6 +89,21 @@ macro_rules! adapter_for {
                     })
                     .map_err(|error| Box::new(error) as DynError)
             }
+
+            async fn get_commitments(
+                &self,
+                blob_id: BlobId,
+            ) -> Result<Option<DaSharesCommitments>, DynError> {
+                let (sender, reply_receiver) = oneshot::channel();
+                self.network_relay
+                    .send(DaNetworkMsg::GetCommitments {
+                        blob_id,
+                        sender,
+                    })
+                    .await
+                    .expect("RequestCommitments message should have been sent");
+                reply_receiver.await.map_err(|_| "Failed to receive commitments reply".into())
+            }
         }
     }
 }

--- a/nomos-services/data-availability/sampling/src/network/adapters/executor.rs
+++ b/nomos-services/data-availability/sampling/src/network/adapters/executor.rs
@@ -13,7 +13,7 @@ use nomos_da_network_service::{
             DaNetworkEvent, DaNetworkEventKind, DaNetworkExecutorBackend, ExecutorDaNetworkMessage,
         },
     },
-    membership::MembershipAdapter,
+    membership::{handler::DaMembershipHandler, MembershipAdapter},
     DaNetworkMsg, NetworkService,
 };
 use overwatch::{

--- a/nomos-services/data-availability/sampling/src/network/adapters/validator.rs
+++ b/nomos-services/data-availability/sampling/src/network/adapters/validator.rs
@@ -13,7 +13,7 @@ use nomos_da_network_service::{
             DaNetworkEvent, DaNetworkEventKind, DaNetworkMessage, DaNetworkValidatorBackend,
         },
     },
-    membership::MembershipAdapter,
+    membership::{handler::DaMembershipHandler, MembershipAdapter},
     DaNetworkMsg, NetworkService,
 };
 use overwatch::{

--- a/nomos-services/data-availability/sampling/src/network/mod.rs
+++ b/nomos-services/data-availability/sampling/src/network/mod.rs
@@ -3,6 +3,7 @@ pub mod adapters;
 use std::pin::Pin;
 
 use futures::Stream;
+use kzgrs_backend::common::share::DaSharesCommitments;
 use nomos_core::da::BlobId;
 use nomos_da_network_service::{
     api::ApiAdapter,
@@ -41,4 +42,9 @@ pub trait NetworkAdapter<RuntimeServiceId> {
     async fn listen_to_sampling_messages(
         &self,
     ) -> Result<Pin<Box<dyn Stream<Item = SamplingEvent> + Send>>, DynError>;
+
+    async fn get_commitments(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<Option<DaSharesCommitments>, DynError>;
 }

--- a/nomos-services/data-availability/verifier/src/network/adapters/common.rs
+++ b/nomos-services/data-availability/verifier/src/network/adapters/common.rs
@@ -56,7 +56,7 @@ macro_rules! adapter_for {
                     Share = DaShare,
                     BlobId = BlobId,
                     Commitments = DaSharesCommitments,
-                    Membership = Membership,
+                    Membership = DaMembershipHandler<Membership>,
                 > + Clone
                 + Send
                 + Sync

--- a/nomos-services/data-availability/verifier/src/network/adapters/executor.rs
+++ b/nomos-services/data-availability/verifier/src/network/adapters/executor.rs
@@ -8,7 +8,7 @@ use nomos_da_network_core::SubnetworkId;
 use nomos_da_network_service::{
     api::ApiAdapter as ApiAdapterTrait,
     backends::libp2p::executor::{DaNetworkEvent, DaNetworkEventKind, DaNetworkExecutorBackend},
-    membership::MembershipAdapter,
+    membership::{handler::DaMembershipHandler, MembershipAdapter},
     NetworkService,
 };
 use overwatch::services::{relay::OutboundRelay, ServiceData};

--- a/nomos-services/data-availability/verifier/src/network/adapters/validator.rs
+++ b/nomos-services/data-availability/verifier/src/network/adapters/validator.rs
@@ -8,7 +8,7 @@ use nomos_da_network_core::SubnetworkId;
 use nomos_da_network_service::{
     api::ApiAdapter as ApiAdapterTrait,
     backends::libp2p::validator::{DaNetworkEvent, DaNetworkEventKind, DaNetworkValidatorBackend},
-    membership::MembershipAdapter,
+    membership::{handler::DaMembershipHandler, MembershipAdapter},
     NetworkService,
 };
 use overwatch::services::{relay::OutboundRelay, ServiceData};


### PR DESCRIPTION
This PR introduces da-network message and uses it from da-sampling.

Context: https://github.com/logos-co/nomos/pull/1435.