### PR TITLE
feat(da): Sampling retry connecting to subnetwork peer

### DIFF
--- a/nodes/nomos-executor/config.yaml
+++ b/nodes/nomos-executor/config.yaml
@@ -70,6 +70,7 @@ da_network:
         seen_message_ttl: "3600.0"
       subnets_settings:
         num_of_subnets: 20
+        retry_limit: 5
       refresh_interval:
         secs: 30
         nanos: 0

--- a/nodes/nomos-node/config.yaml
+++ b/nodes/nomos-node/config.yaml
@@ -69,6 +69,7 @@ da_network:
       seen_message_ttl: "3600.0"
     subnets_settings:
       num_of_subnets: 20
+      retry_limit: 5
     refresh_interval:
       secs: 30
       nanos: 0

--- a/nomos-da/network/core/src/protocols/sampling/connections.rs
+++ b/nomos-da/network/core/src/protocols/sampling/connections.rs
@@ -1,0 +1,108 @@
+use std::collections::{HashMap, HashSet};
+
+use libp2p::PeerId;
+
+use crate::SubnetworkId;
+
+type RetryCount = usize;
+
+pub struct Connections {
+    pending_connections: HashMap<SubnetworkId, RetryCount>,
+    pending_peers: HashMap<PeerId, HashSet<SubnetworkId>>,
+    failed_peers: HashSet<PeerId>,
+    retry_limit: usize,
+}
+
+impl Connections {
+    pub fn new(retry_limit: usize) -> Self {
+        Self {
+            pending_connections: HashMap::new(),
+            pending_peers: HashMap::new(),
+            failed_peers: HashSet::new(),
+            retry_limit,
+        }
+    }
+
+    pub fn register_connect(&mut self, peer: PeerId) {
+        self.failed_peers.remove(&peer);
+        if let Some(subnets) = self.pending_peers.get(&peer) {
+            for subnet in subnets {
+                self.pending_connections.insert(*subnet, 0);
+            }
+        }
+    }
+
+    pub fn register_disconnect(&mut self, peer: PeerId) {
+        if let Some(subnets) = self.pending_peers.get(&peer) {
+            self.failed_peers.insert(peer);
+            for subnet in subnets {
+                self.pending_connections
+                    .entry(*subnet)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+            }
+        }
+    }
+
+    pub fn register_pending_peer(&mut self, peer: PeerId, subnet: SubnetworkId) {
+        self.pending_connections.insert(subnet, 0);
+        self.pending_peers.entry(peer).or_default().insert(subnet);
+    }
+
+    pub fn should_retry(&self, subnet: SubnetworkId) -> bool {
+        // If we don't track the subnetwork yet, we should try to connect to it.
+        self.pending_connections
+            .get(&subnet)
+            .is_none_or(|&retries| retries < self.retry_limit)
+    }
+
+    pub fn should_requeue(&self, peer: PeerId) -> bool {
+        self.failed_peers.contains(&peer)
+    }
+
+    pub fn clear(&mut self) {
+        self.pending_connections.clear();
+        self.pending_peers.clear();
+        self.failed_peers.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_connection_limits() {
+        let retry_limit = 2;
+        let mut connections = Connections::new(retry_limit);
+
+        let peer = PeerId::random();
+        let subnet = 1;
+
+        connections.register_pending_peer(peer, subnet);
+        assert_eq!(connections.pending_connections.get(&subnet), Some(&0));
+        assert!(connections.should_retry(subnet));
+
+        connections.register_disconnect(peer);
+        assert_eq!(connections.pending_connections.get(&subnet), Some(&1));
+        assert!(connections.should_retry(subnet));
+
+        connections.register_connect(peer);
+        assert_eq!(connections.pending_connections.get(&subnet), Some(&0));
+        assert!(!connections.should_requeue(peer));
+        assert!(connections.should_retry(subnet));
+
+        connections.register_disconnect(peer);
+        assert!(connections.should_requeue(peer));
+        connections.register_disconnect(peer);
+        connections.register_disconnect(peer);
+
+        assert_eq!(connections.pending_connections.get(&subnet), Some(&3));
+        assert!(!connections.should_retry(subnet));
+
+        connections.clear();
+        assert_eq!(connections.pending_connections.len(), 0);
+        assert_eq!(connections.pending_peers.len(), 0);
+        assert!(connections.should_retry(subnet));
+    }
+}

--- a/nomos-da/network/core/src/protocols/sampling/mod.rs
+++ b/nomos-da/network/core/src/protocols/sampling/mod.rs
@@ -1,4 +1,5 @@
 pub mod behaviour;
+mod connections;
 
 #[cfg(test)]
 mod test {
@@ -105,7 +106,10 @@ mod test {
         let p1_behavior = SamplingBehaviour::new(
             PeerId::from_public_key(&k1.public()),
             neighbours_p1.clone(),
-            SubnetsConfig { num_of_subnets: 1 },
+            SubnetsConfig {
+                num_of_subnets: 1,
+                retry_limit: 1,
+            },
             Box::pin(IntervalStream::new(time::interval(Duration::from_secs(1))).map(|_| ())),
         );
 
@@ -114,7 +118,10 @@ mod test {
         let p2_behavior = SamplingBehaviour::new(
             PeerId::from_public_key(&k2.public()),
             neighbours_p1.clone(),
-            SubnetsConfig { num_of_subnets: 1 },
+            SubnetsConfig {
+                num_of_subnets: 1,
+                retry_limit: 1,
+            },
             Box::pin(IntervalStream::new(time::interval(Duration::from_secs(1))).map(|_| ())),
         );
         let mut p2 = new_swarm_in_memory(&k2, p2_behavior);

--- a/testnet/cfgsync/src/config.rs
+++ b/testnet/cfgsync/src/config.rs
@@ -358,6 +358,7 @@ mod cfgsync_tests {
                     seen_message_ttl: Duration::ZERO,
                 },
                 subnets_refresh_interval: Duration::from_secs(1),
+                retry_subnets_limit: 1,
             },
             &TracingSettings {
                 logger: LoggerLayer::None,

--- a/testnet/cfgsync/src/server.rs
+++ b/testnet/cfgsync/src/server.rs
@@ -98,6 +98,7 @@ impl CfgSyncConfig {
             redial_cooldown: Duration::ZERO,
             replication_settings: self.replication_settings,
             subnets_refresh_interval: Duration::from_secs(30),
+            retry_subnets_limit: 1,
         }
     }
 

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -336,6 +336,7 @@ pub fn create_executor_config(config: GeneralConfig) -> Config {
                     replication_settings: config.da_config.replication_settings,
                     subnets_settings: SubnetsConfig {
                         num_of_subnets: config.da_config.num_samples as usize,
+                        retry_limit: config.da_config.retry_subnets_limit,
                     },
                     refresh_interval: config.da_config.subnets_refresh_interval,
                 },

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -388,6 +388,7 @@ pub fn create_validator_config(config: GeneralConfig) -> Config {
                 replication_settings: config.da_config.replication_settings,
                 subnets_settings: SubnetsConfig {
                     num_of_subnets: config.da_config.num_samples as usize,
+                    retry_limit: config.da_config.retry_subnets_limit,
                 },
                 refresh_interval: config.da_config.subnets_refresh_interval,
             },

--- a/tests/src/topology/configs/da.rs
+++ b/tests/src/topology/configs/da.rs
@@ -44,6 +44,7 @@ pub struct DaParams {
     pub redial_cooldown: Duration,
     pub replication_settings: ReplicationConfig,
     pub subnets_refresh_interval: Duration,
+    pub retry_subnets_limit: usize,
 }
 
 impl Default for DaParams {
@@ -80,6 +81,7 @@ impl Default for DaParams {
                 seen_message_ttl: Duration::from_secs(3600),
             },
             subnets_refresh_interval: Duration::from_secs(5),
+            retry_subnets_limit: 1,
         }
     }
 }
@@ -105,6 +107,7 @@ pub struct GeneralDaConfig {
     pub redial_cooldown: Duration,
     pub replication_settings: ReplicationConfig,
     pub subnets_refresh_interval: Duration,
+    pub retry_subnets_limit: usize,
 }
 
 #[must_use]
@@ -170,6 +173,7 @@ pub fn create_da_configs(
                 redial_cooldown: da_params.redial_cooldown,
                 replication_settings: da_params.replication_settings,
                 subnets_refresh_interval: da_params.subnets_refresh_interval,
+                retry_subnets_limit: da_params.retry_subnets_limit,
             }
         })
         .collect()


### PR DESCRIPTION
## 1. What does this PR implement?

Add retry connections to a subnetwork peer with a configurable limit.
A simplified flow:
- Sampling subnetwork set is selected.
- Sample request for blob is sent to selected peers.
- If dialing fails, sampling task handler checks if it's because of Dial error.
- If retry limit is not reached, sample request for that subnetwork is enqueued.
- If limit is reached, sampling error is returned to the service for that blob.

## 2. Does the code have enough context to be clearly understood?

Related [Spec](https://www.notion.so/nomos-tech/NomosDA-Sampling-1fd261aa09df81dcb3c6ebc99206a0b1?source=copy_link#1fd261aa09df81e2b25ae612631a6d5d) section.

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @bacv 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
