### PR TITLE
chore(lints): enforce low-pain rustc and Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,6 @@ deref_into_dyn_supertrait                    = { level = "allow" }
 edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
-if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
 keyword-idents                               = { level = "allow" }
 keyword_idents_2018                          = { level = "allow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,7 +243,6 @@ deprecated_safe_2024                         = { level = "allow" }
 deref_into_dyn_supertrait                    = { level = "allow" }
 edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
-explicit_outlives_requirements               = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,6 @@ cast_possible_wrap          = { level = "allow" }
 cast_precision_loss         = { level = "allow" }
 cast_sign_loss              = { level = "allow" }
 cfg_not_test                = { level = "allow" }
-dbg_macro                   = { level = "allow" }
 error_impl_error            = { level = "allow" }
 impl_trait_in_params        = { level = "allow" }
 indexing_slicing            = { level = "allow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,9 +245,6 @@ edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
-keyword-idents                               = { level = "allow" }
-keyword_idents_2018                          = { level = "allow" }
-keyword_idents_2024                          = { level = "allow" }
 let_underscore_drop                          = { level = "allow" }
 linker_messages                              = { level = "allow" }
 macro_use_extern_crate                       = { level = "allow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,7 +254,6 @@ macro_use_extern_crate                       = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }
-non_ascii_idents                             = { level = "allow" }
 rust_2021_incompatible_closure_captures      = { level = "allow" }
 rust_2021_incompatible_or_patterns           = { level = "allow" }
 rust_2021_prefixes_incompatible_syntax       = { level = "allow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,7 +251,6 @@ keyword_idents_2024                          = { level = "allow" }
 let_underscore_drop                          = { level = "allow" }
 linker_messages                              = { level = "allow" }
 macro_use_extern_crate                       = { level = "allow" }
-meta_variable_misuse                         = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,6 @@ cast_possible_truncation    = { level = "allow" }
 cast_possible_wrap          = { level = "allow" }
 cast_precision_loss         = { level = "allow" }
 cast_sign_loss              = { level = "allow" }
-cfg_not_test                = { level = "allow" }
 error_impl_error            = { level = "allow" }
 impl_trait_in_params        = { level = "allow" }
 indexing_slicing            = { level = "allow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,6 @@ rust_2024_prelude_collisions                 = { level = "allow" }
 tail_expr_drop_order                         = { level = "allow" }
 trivial_casts                                = { level = "allow" }
 unit_bindings                                = { level = "allow" }
-unnameable_types                             = { level = "allow" }
 unreachable_pub                              = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -140,7 +140,6 @@ deprecated_safe_2024                         = { level = "allow" }
 deref_into_dyn_supertrait                    = { level = "allow" }
 edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
-explicit_outlives_requirements               = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -85,7 +85,6 @@ cast_possible_wrap          = { level = "allow" }
 cast_precision_loss         = { level = "allow" }
 cast_sign_loss              = { level = "allow" }
 cfg_not_test                = { level = "allow" }
-dbg_macro                   = { level = "allow" }
 error_impl_error            = { level = "allow" }
 impl_trait_in_params        = { level = "allow" }
 indexing_slicing            = { level = "allow" }

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -151,7 +151,6 @@ macro_use_extern_crate                       = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }
-non_ascii_idents                             = { level = "allow" }
 rust_2021_incompatible_closure_captures      = { level = "allow" }
 rust_2021_incompatible_or_patterns           = { level = "allow" }
 rust_2021_prefixes_incompatible_syntax       = { level = "allow" }

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -84,7 +84,6 @@ cast_possible_truncation    = { level = "allow" }
 cast_possible_wrap          = { level = "allow" }
 cast_precision_loss         = { level = "allow" }
 cast_sign_loss              = { level = "allow" }
-cfg_not_test                = { level = "allow" }
 error_impl_error            = { level = "allow" }
 impl_trait_in_params        = { level = "allow" }
 indexing_slicing            = { level = "allow" }

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -142,9 +142,6 @@ edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
-keyword-idents                               = { level = "allow" }
-keyword_idents_2018                          = { level = "allow" }
-keyword_idents_2024                          = { level = "allow" }
 let_underscore_drop                          = { level = "allow" }
 linker_messages                              = { level = "allow" }
 macro_use_extern_crate                       = { level = "allow" }

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -161,7 +161,6 @@ rust_2024_prelude_collisions                 = { level = "allow" }
 tail_expr_drop_order                         = { level = "allow" }
 trivial_casts                                = { level = "allow" }
 unit_bindings                                = { level = "allow" }
-unnameable_types                             = { level = "allow" }
 unreachable_pub                              = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -141,7 +141,6 @@ deref_into_dyn_supertrait                    = { level = "allow" }
 edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
-if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
 keyword-idents                               = { level = "allow" }
 keyword_idents_2018                          = { level = "allow" }

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -148,7 +148,6 @@ keyword_idents_2024                          = { level = "allow" }
 let_underscore_drop                          = { level = "allow" }
 linker_messages                              = { level = "allow" }
 macro_use_extern_crate                       = { level = "allow" }
-meta_variable_misuse                         = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -150,9 +150,6 @@ edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
-keyword-idents                               = { level = "allow" }
-keyword_idents_2018                          = { level = "allow" }
-keyword_idents_2024                          = { level = "allow" }
 let_underscore_drop                          = { level = "allow" }
 linker_messages                              = { level = "allow" }
 macro_use_extern_crate                       = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -159,7 +159,6 @@ macro_use_extern_crate                       = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }
-non_ascii_idents                             = { level = "allow" }
 rust_2021_incompatible_closure_captures      = { level = "allow" }
 rust_2021_incompatible_or_patterns           = { level = "allow" }
 rust_2021_prefixes_incompatible_syntax       = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -169,7 +169,6 @@ rust_2024_prelude_collisions                 = { level = "allow" }
 tail_expr_drop_order                         = { level = "allow" }
 trivial_casts                                = { level = "allow" }
 unit_bindings                                = { level = "allow" }
-unnameable_types                             = { level = "allow" }
 unreachable_pub                              = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -148,7 +148,6 @@ deprecated_safe_2024                         = { level = "allow" }
 deref_into_dyn_supertrait                    = { level = "allow" }
 edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
-explicit_outlives_requirements               = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -93,7 +93,6 @@ cast_possible_wrap          = { level = "allow" }
 cast_precision_loss         = { level = "allow" }
 cast_sign_loss              = { level = "allow" }
 cfg_not_test                = { level = "allow" }
-dbg_macro                   = { level = "allow" }
 error_impl_error            = { level = "allow" }
 impl_trait_in_params        = { level = "allow" }
 indexing_slicing            = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -149,7 +149,6 @@ deref_into_dyn_supertrait                    = { level = "allow" }
 edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
-if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
 keyword-idents                               = { level = "allow" }
 keyword_idents_2018                          = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -92,7 +92,6 @@ cast_possible_truncation    = { level = "allow" }
 cast_possible_wrap          = { level = "allow" }
 cast_precision_loss         = { level = "allow" }
 cast_sign_loss              = { level = "allow" }
-cfg_not_test                = { level = "allow" }
 error_impl_error            = { level = "allow" }
 impl_trait_in_params        = { level = "allow" }
 indexing_slicing            = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -156,7 +156,6 @@ keyword_idents_2024                          = { level = "allow" }
 let_underscore_drop                          = { level = "allow" }
 linker_messages                              = { level = "allow" }
 macro_use_extern_crate                       = { level = "allow" }
-meta_variable_misuse                         = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -146,7 +146,6 @@ deprecated_safe_2024                         = { level = "allow" }
 deref_into_dyn_supertrait                    = { level = "allow" }
 edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
-explicit_outlives_requirements               = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -147,7 +147,6 @@ deref_into_dyn_supertrait                    = { level = "allow" }
 edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
-if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
 keyword-idents                               = { level = "allow" }
 keyword_idents_2018                          = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -154,7 +154,6 @@ keyword_idents_2024                          = { level = "allow" }
 let_underscore_drop                          = { level = "allow" }
 linker_messages                              = { level = "allow" }
 macro_use_extern_crate                       = { level = "allow" }
-meta_variable_misuse                         = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -148,9 +148,6 @@ edition_2024_expr_fragment_specifier         = { level = "allow" }
 elided_lifetimes_in_paths                    = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
-keyword-idents                               = { level = "allow" }
-keyword_idents_2018                          = { level = "allow" }
-keyword_idents_2024                          = { level = "allow" }
 let_underscore_drop                          = { level = "allow" }
 linker_messages                              = { level = "allow" }
 macro_use_extern_crate                       = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -157,7 +157,6 @@ macro_use_extern_crate                       = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }
-non_ascii_idents                             = { level = "allow" }
 rust_2021_incompatible_closure_captures      = { level = "allow" }
 rust_2021_incompatible_or_patterns           = { level = "allow" }
 rust_2021_prefixes_incompatible_syntax       = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -90,7 +90,6 @@ cast_possible_truncation    = { level = "allow" }
 cast_possible_wrap          = { level = "allow" }
 cast_precision_loss         = { level = "allow" }
 cast_sign_loss              = { level = "allow" }
-cfg_not_test                = { level = "allow" }
 error_impl_error            = { level = "allow" }
 impl_trait_in_params        = { level = "allow" }
 indexing_slicing            = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -167,7 +167,6 @@ rust_2024_prelude_collisions                 = { level = "allow" }
 tail_expr_drop_order                         = { level = "allow" }
 trivial_casts                                = { level = "allow" }
 unit_bindings                                = { level = "allow" }
-unnameable_types                             = { level = "allow" }
 unreachable_pub                              = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -91,7 +91,6 @@ cast_possible_wrap          = { level = "allow" }
 cast_precision_loss         = { level = "allow" }
 cast_sign_loss              = { level = "allow" }
 cfg_not_test                = { level = "allow" }
-dbg_macro                   = { level = "allow" }
 error_impl_error            = { level = "allow" }
 impl_trait_in_params        = { level = "allow" }
 indexing_slicing            = { level = "allow" }

--- a/nomos-services/tracing/src/lib.rs
+++ b/nomos-services/tracing/src/lib.rs
@@ -165,9 +165,8 @@ where
         service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
         _initial_state: Self::State,
     ) -> Result<Self, overwatch::DynError> {
-        #[cfg(test)]
         use std::sync::Once;
-        #[cfg(test)]
+
         static ONCE_INIT: Once = Once::new();
 
         let config = service_resources_handle
@@ -237,18 +236,12 @@ where
             });
         }
 
-        #[cfg(test)]
         ONCE_INIT.call_once(move || {
             tracing_subscriber::registry()
                 .with(LevelFilter::from(config.level))
                 .with(layers)
                 .init();
         });
-        #[cfg(not(test))]
-        tracing_subscriber::registry()
-            .with(LevelFilter::from(config.level))
-            .with(layers)
-            .init();
 
         panic::set_hook(Box::new(nomos_tracing::panic::panic_hook));
 


### PR DESCRIPTION
## 1. What does this PR implement?

Enforce the last lints that make sense to enforce AND are low pain since they do not require big changes. Next, we will start enabling one lint at the time, most likely.

### Clippy lints

* [clippy::cfg_not_test](https://rust-lang.github.io/rust-clippy/master/index.html#/cfg_not_test): we had one instance. In that case, the tracing crate would anyway panic if called more than once, so it does not hurt to run the initialization function once only, also outside of tests.
* [clippy::dbg_macro](https://rust-lang.github.io/rust-clippy/master/index.html#/dbg_macro): we have debug logs instead. In the past, one of these slipped in the Overwatch crate and was polluting all the logs because there is no way of filtering them. `debug_assert`s can still be used. No affected code.

### Rustc lints

* [explicit_outlives_requirements](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#explicit-outlives-requirements): less code to write, the better. No affected code.
* [if_let_rescope](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#if-let-rescope): the explanation is quite exhaustive. No affected code.
* [keyword-idents](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#keyword-idents), [keyword-idents-2018](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#keyword-idents-2018), [keyword-idents-2024](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#keyword-idents-2024): same as previous point. No affected code.
* [meta_variable_misuse](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#meta-variable-misuse): less error-prone macros. No affected code.
* [non_ascii_idents](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#non-ascii-idents): No affected code.
* [unnameable_types](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#unnameable-types): exhaustive explanation in the lint description. No affected code.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
