### PR TITLE
chore(sampling): Split sampling behaviour

### DIFF
--- a/nomos-da/network/core/src/behaviour/executor.rs
+++ b/nomos-da/network/core/src/behaviour/executor.rs
@@ -15,7 +15,7 @@ use crate::{
             validator::behaviour::DispersalValidatorBehaviour,
         },
         replication::behaviour::{ReplicationBehaviour, ReplicationConfig},
-        sampling::{behaviour::SamplingBehaviour, SubnetsConfig},
+        sampling::{SamplingBehaviour, SubnetsConfig},
     },
 };
 

--- a/nomos-da/network/core/src/behaviour/validator.rs
+++ b/nomos-da/network/core/src/behaviour/validator.rs
@@ -12,7 +12,7 @@ use crate::{
     protocols::{
         dispersal::validator::behaviour::DispersalValidatorBehaviour,
         replication::behaviour::{ReplicationBehaviour, ReplicationConfig},
-        sampling::{behaviour::SamplingBehaviour, SubnetsConfig},
+        sampling::{SamplingBehaviour, SubnetsConfig},
     },
 };
 

--- a/nomos-da/network/core/src/protocols/sampling/requests/mod.rs
+++ b/nomos-da/network/core/src/protocols/sampling/requests/mod.rs
@@ -1,0 +1,24 @@
+use kzgrs_backend::common::share::{DaLightShare, DaSharesCommitments};
+use nomos_core::da::BlobId;
+use subnetworks_assignations::SubnetworkId;
+
+use crate::protocols::sampling::errors::SamplingError;
+
+pub mod request_behaviour;
+
+#[derive(Debug)]
+pub enum SamplingEvent {
+    /// A blob successfully arrived its destination
+    SamplingSuccess {
+        blob_id: BlobId,
+        subnetwork_id: SubnetworkId,
+        light_share: Box<DaLightShare>,
+    },
+    CommitmentsSuccess {
+        blob_id: BlobId,
+        commitments: Box<DaSharesCommitments>,
+    },
+    SamplingError {
+        error: SamplingError,
+    },
+}

--- a/nomos-da/network/core/src/protocols/sampling/responses/mod.rs
+++ b/nomos-da/network/core/src/protocols/sampling/responses/mod.rs
@@ -1,0 +1,16 @@
+use futures::channel::oneshot::{Receiver, Sender};
+
+use crate::protocols::sampling::{errors::SamplingError, BehaviourSampleReq, BehaviourSampleRes};
+
+pub mod response_behaviour;
+
+#[derive(Debug)]
+pub enum SamplingEvent {
+    IncomingSample {
+        request_receiver: Receiver<BehaviourSampleReq>,
+        response_sender: Sender<BehaviourSampleRes>,
+    },
+    SamplingError {
+        error: SamplingError,
+    },
+}

--- a/nomos-da/network/core/src/protocols/sampling/responses/response_behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/responses/response_behaviour.rs
@@ -1,0 +1,279 @@
+use std::{
+    collections::VecDeque,
+    task::{Context, Poll, Waker},
+};
+
+use either::Either;
+use futures::{
+    channel::{
+        oneshot,
+        oneshot::{Receiver, Sender},
+    },
+    stream::FuturesUnordered,
+    AsyncWriteExt as _, FutureExt as _, StreamExt as _,
+};
+use libp2p::{
+    core::{transport::PortUse, Endpoint},
+    swarm::{
+        ConnectionDenied, ConnectionId, DialFailure, FromSwarm, NetworkBehaviour, THandler,
+        THandlerInEvent, THandlerOutEvent, ToSwarm,
+    },
+    Multiaddr, PeerId,
+};
+use libp2p_stream::IncomingStreams;
+use nomos_da_messages::sampling;
+
+use crate::{
+    protocol::SAMPLING_PROTOCOL,
+    protocols::sampling::{
+        connections::Connections,
+        errors::SamplingError,
+        responses::SamplingEvent,
+        streams::{self, SampleStream},
+        BehaviourSampleReq, BehaviourSampleRes, ResponseChannel, SamplingRequestStreamFuture,
+        SubnetsConfig,
+    },
+};
+
+/// Executor sampling protocol
+/// Takes care of sending and replying sampling requests
+pub struct ResponseSamplingBehaviour {
+    /// Underlying stream behaviour
+    stream_behaviour: libp2p_stream::Behaviour,
+    /// Incoming sample request streams
+    incoming_streams: IncomingStreams,
+    /// Pending sampling stream tasks
+    stream_tasks: FuturesUnordered<SamplingRequestStreamFuture>,
+    /// Sample streams that has no tasks and should be closed.
+    to_close: VecDeque<SampleStream>,
+    /// Pending subnetwork connections for randomly selected peers after refresh
+    /// interval.
+    connections: Connections,
+    /// Waker for sampling polling
+    waker: Option<Waker>,
+}
+
+impl ResponseSamplingBehaviour {
+    pub fn new(subnets_config: SubnetsConfig) -> Self {
+        let stream_behaviour = libp2p_stream::Behaviour::new();
+        let mut control = stream_behaviour.new_control();
+
+        let incoming_streams = control
+            .accept(SAMPLING_PROTOCOL)
+            .expect("Just a single accept to protocol is valid");
+
+        let stream_tasks = FuturesUnordered::new();
+        let to_close = VecDeque::new();
+
+        let connections = Connections::new(subnets_config.shares_retry_limit);
+
+        Self {
+            stream_behaviour,
+            incoming_streams,
+            stream_tasks,
+            to_close,
+            connections,
+            waker: None,
+        }
+    }
+
+    /// Schedule an incoming stream to be replied
+    /// Creates the necessary channels so requests can be replied from outside
+    /// of this behaviour from whoever that takes the channels
+    fn schedule_incoming_stream_task(
+        &self,
+        sample_stream: SampleStream,
+    ) -> (Receiver<BehaviourSampleReq>, Sender<BehaviourSampleRes>) {
+        let (request_sender, request_receiver) = oneshot::channel();
+        let (response_sender, response_receiver) = oneshot::channel();
+        let channel = ResponseChannel {
+            request_sender,
+            response_receiver,
+        };
+        self.stream_tasks
+            .push(streams::handle_incoming_stream(sample_stream, channel).boxed());
+        // Scheduled a task, lets poll again.
+        (request_receiver, response_sender)
+    }
+
+    pub fn try_wake(&mut self) {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+    }
+    fn handle_stream_response(
+        &self,
+        _peer_id: PeerId,
+        stream: SampleStream,
+    ) -> Poll<ToSwarm<<Self as NetworkBehaviour>::ToSwarm, THandlerInEvent<Self>>> {
+        // Writer might behoping to send to this stream another request, wait
+        // until the writer closes the stream.
+        let (request_receiver, response_sender) = self.schedule_incoming_stream_task(stream);
+        Poll::Ready(ToSwarm::GenerateEvent(SamplingEvent::IncomingSample {
+            request_receiver,
+            response_sender,
+        }))
+    }
+
+    fn handle_stream_error(
+        &mut self,
+        error: SamplingError,
+        maybe_stream: Option<SampleStream>,
+    ) -> Option<Poll<ToSwarm<<Self as NetworkBehaviour>::ToSwarm, THandlerInEvent<Self>>>> {
+        match error {
+            SamplingError::Io {
+                error,
+                message: Some(sampling::SampleRequest::Share(message)),
+                ..
+            } if error.kind() == std::io::ErrorKind::ConnectionReset => {
+                // Propagate error for blob_id if retry limit is reached.
+                if !self.connections.should_retry(message.share_idx) {
+                    return Some(Poll::Ready(ToSwarm::GenerateEvent(
+                        SamplingEvent::SamplingError {
+                            error: SamplingError::NoSubnetworkPeers {
+                                blob_id: message.blob_id,
+                                subnetwork_id: message.share_idx,
+                            },
+                        },
+                    )));
+                }
+                // Stream is useless if connection was reset.
+                if let Some(stream) = maybe_stream {
+                    self.to_close.push_back(stream);
+                }
+                None
+            }
+            SamplingError::Io { error, .. }
+                if error.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                // Eof is actually expected and is proper signal about remote closing the
+                // stream. Do not propagate and continue execution of behaviour poll method.
+                if let Some(stream) = maybe_stream {
+                    self.to_close.push_back(stream);
+                }
+                None
+            }
+            error => {
+                if let Some(stream) = maybe_stream {
+                    self.to_close.push_back(stream);
+                }
+                Some(Poll::Ready(ToSwarm::GenerateEvent(
+                    SamplingEvent::SamplingError { error },
+                )))
+            }
+        }
+    }
+
+    fn poll_stream_tasks(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Option<Poll<ToSwarm<<Self as NetworkBehaviour>::ToSwarm, THandlerInEvent<Self>>>> {
+        if let Poll::Ready(Some(future_result)) = self.stream_tasks.poll_next_unpin(cx) {
+            cx.waker().wake_by_ref();
+            match future_result {
+                Ok((peer_id, stream)) => {
+                    return Some(self.handle_stream_response(peer_id, stream));
+                }
+                Err((error, maybe_stream)) => {
+                    return self.handle_stream_error(error, maybe_stream);
+                }
+            }
+        }
+        None
+    }
+}
+
+impl NetworkBehaviour for ResponseSamplingBehaviour {
+    type ConnectionHandler = Either<
+        <libp2p_stream::Behaviour as NetworkBehaviour>::ConnectionHandler,
+        libp2p::swarm::dummy::ConnectionHandler,
+    >;
+    type ToSwarm = SamplingEvent;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer: PeerId,
+        local_addr: &Multiaddr,
+        remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.stream_behaviour
+            .handle_established_inbound_connection(connection_id, peer, local_addr, remote_addr)
+            .map(Either::Left)
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer: PeerId,
+        addr: &Multiaddr,
+        role_override: Endpoint,
+        port_use: PortUse,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.connections.register_connect(peer);
+        self.stream_behaviour
+            .handle_established_outbound_connection(
+                connection_id,
+                peer,
+                addr,
+                role_override,
+                port_use,
+            )
+            .map(Either::Left)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm) {
+        if let FromSwarm::DialFailure(DialFailure {
+            peer_id: Some(peer_id),
+            ..
+        }) = event
+        {
+            self.connections.register_disconnect(peer_id);
+        }
+        self.stream_behaviour.on_swarm_event(event);
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        event: THandlerOutEvent<Self>,
+    ) {
+        let Either::Left(event) = event;
+        self.stream_behaviour
+            .on_connection_handler_event(peer_id, connection_id, event);
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        self.waker = Some(cx.waker().clone());
+        // poll incoming streams
+        if let Poll::Ready(Some((peer_id, stream))) = self.incoming_streams.poll_next_unpin(cx) {
+            let sample_stream = SampleStream { stream, peer_id };
+            let (request_receiver, response_sender) =
+                self.schedule_incoming_stream_task(sample_stream);
+            cx.waker().wake_by_ref();
+            return Poll::Ready(ToSwarm::GenerateEvent(SamplingEvent::IncomingSample {
+                request_receiver,
+                response_sender,
+            }));
+        }
+
+        // poll stream tasks
+        if let Some(result) = self.poll_stream_tasks(cx) {
+            return result;
+        }
+
+        // Discard stream, if still pending pushback to close later.
+        if let Some(mut stream) = self.to_close.pop_front() {
+            if stream.stream.close().poll_unpin(cx).is_pending() {
+                self.to_close.push_back(stream);
+                cx.waker().wake_by_ref();
+            }
+        }
+
+        Poll::Pending
+    }
+}

--- a/nomos-da/network/core/src/protocols/sampling/streams.rs
+++ b/nomos-da/network/core/src/protocols/sampling/streams.rs
@@ -7,7 +7,7 @@ use nomos_da_messages::{
 
 use super::{
     errors::SamplingError, BehaviourSampleReq, ResponseChannel, SampleFutureError,
-    SampleFutureSuccess, SampleStreamResponse,
+    SampleRequestFutureSuccess, SampleResponseFutureSuccess,
 };
 
 /// Auxiliary struct that binds a stream with the corresponding `PeerId`
@@ -21,7 +21,7 @@ pub struct SampleStream {
 pub async fn stream_sample(
     mut stream: SampleStream,
     message: sampling::SampleRequest,
-) -> Result<SampleFutureSuccess, SampleFutureError> {
+) -> Result<SampleResponseFutureSuccess, SampleFutureError> {
     let peer_id = stream.peer_id;
     if let Err(error) = pack_to_writer(&message, &mut stream.stream).await {
         return Err((
@@ -59,7 +59,7 @@ pub async fn stream_sample(
         }
     };
 
-    Ok((peer_id, SampleStreamResponse::Writer(response), stream))
+    Ok((peer_id, response, stream))
 }
 
 /// Handler for incoming streams
@@ -67,7 +67,7 @@ pub async fn stream_sample(
 pub async fn handle_incoming_stream(
     mut stream: SampleStream,
     channel: ResponseChannel,
-) -> Result<SampleFutureSuccess, SampleFutureError> {
+) -> Result<SampleRequestFutureSuccess, SampleFutureError> {
     let peer_id = stream.peer_id;
     let request: sampling::SampleRequest = match unpack_from_reader(&mut stream.stream).await {
         Ok(req) => req,
@@ -132,5 +132,5 @@ pub async fn handle_incoming_stream(
         ));
     }
 
-    Ok((peer_id, SampleStreamResponse::Reader, stream))
+    Ok((peer_id, stream))
 }


### PR DESCRIPTION
## 1. What does this PR implement?

We are splitting sampling behavior into 2 independent behaviors. One for requests and one for responses.
This already remove the limitation of sample replies to external (out of DA network) entities.
This is a previous step for having and extra behavior for historical DA sampling.

## 2. Does the code have enough context to be clearly understood?

It just split and moves things around, then regroup them in a single behavior.

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @bacv 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
