### PR TITLE
chore: Remove unnecessary heap allocation

### DIFF
--- a/nomos-services/utils/src/overwatch/status/service_status_entry/entry.rs
+++ b/nomos-services/utils/src/overwatch/status/service_status_entry/entry.rs
@@ -24,7 +24,6 @@ impl<RuntimeServiceId> ServiceStatusEntry<RuntimeServiceId> {
 impl<RuntimeServiceId: Display> Display for ServiceStatusEntry<RuntimeServiceId> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Self { id, status } = self;
-        let id = id.to_string();
         write!(f, "{id}: {status}")
     }
 }
@@ -32,7 +31,6 @@ impl<RuntimeServiceId: Display> Display for ServiceStatusEntry<RuntimeServiceId>
 impl<RuntimeServiceId: Display> Debug for ServiceStatusEntry<RuntimeServiceId> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Self { id, status } = self;
-        let id = id.to_string();
         write!(f, "ServiceStatusEntry {{ id: {id}, status: {status:?} }}")
     }
 }

--- a/nomos-services/utils/src/overwatch/status/service_status_entry/error.rs
+++ b/nomos-services/utils/src/overwatch/status/service_status_entry/error.rs
@@ -12,13 +12,15 @@ pub struct ServiceStatusEntriesError<RuntimeServiceId: Display> {
 
 impl<RuntimeServiceId: Display> Display for ServiceStatusEntriesError<RuntimeServiceId> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let entries: Vec<String> = self
-            .service_status_entries
-            .iter()
-            .map(ToString::to_string)
-            .collect();
-        let entries = entries.join(", ");
-        write!(f, "ServiceStatuses: {entries}")
+        let mut iter = self.service_status_entries.iter();
+        write!(f, "ServiceStatuses: [")?;
+        if let Some(elem) = iter.next() {
+            write!(f, "{elem}")?;
+        }
+        for elem in iter {
+            write!(f, ", {elem}")?;
+        }
+        write!(f, "]")
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

It is not necessary to call `ToString::to_string` when passing a parameter to one of the formatting macros.
