### PR TITLE
test(blend): add core->edge behavior tests

### DIFF
--- a/nomos-blend/network/Cargo.toml
+++ b/nomos-blend/network/Cargo.toml
@@ -23,6 +23,7 @@ tracing                = { workspace = true }
 [dev-dependencies]
 async-trait         = { version = "0.1" }
 libp2p              = { workspace = true, features = ["ed25519", "tokio"] }
+libp2p-stream       = { workspace = true }
 libp2p-swarm-test   = { version = "0.5.0", features = ["tokio"] }
 nomos-blend-message = { workspace = true, features = ["unsafe-test-functions"] }
 test-log            = { version = "0.2.18", features = ["trace"] }

--- a/nomos-blend/network/src/core/mod.rs
+++ b/nomos-blend/network/src/core/mod.rs
@@ -1,6 +1,9 @@
 pub mod with_core;
 pub mod with_edge;
 
+#[cfg(test)]
+mod tests;
+
 use libp2p::PeerId;
 use nomos_blend_scheduling::membership::Membership;
 

--- a/nomos-blend/network/src/core/tests/mod.rs
+++ b/nomos-blend/network/src/core/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/nomos-blend/network/src/core/tests/utils.rs
+++ b/nomos-blend/network/src/core/tests/utils.rs
@@ -1,0 +1,124 @@
+use core::{
+    fmt::Debug,
+    iter::repeat_with,
+    ops::{Deref, DerefMut},
+};
+
+use libp2p::{
+    identity::{ed25519::PublicKey, Keypair},
+    PeerId, Swarm,
+};
+use libp2p_swarm_test::SwarmExt as _;
+use nomos_blend_message::{
+    crypto::{
+        Ed25519PrivateKey, ProofOfQuota, ProofOfSelection, Signature, PROOF_OF_QUOTA_SIZE,
+        SIGNATURE_SIZE,
+    },
+    input::{EncapsulationInput, EncapsulationInputs},
+    PayloadType,
+};
+use nomos_blend_scheduling::EncapsulatedMessage;
+use nomos_libp2p::NetworkBehaviour;
+
+pub struct TestSwarm<Behaviour>(Swarm<Behaviour>)
+where
+    Behaviour: NetworkBehaviour;
+
+impl<Behaviour> TestSwarm<Behaviour>
+where
+    Behaviour: NetworkBehaviour<ToSwarm: Debug> + Send,
+{
+    pub fn new<BehaviourConstructor>(behaviour_fn: BehaviourConstructor) -> Self
+    where
+        BehaviourConstructor: FnOnce(Keypair) -> Behaviour,
+    {
+        Self(Swarm::new_ephemeral_tokio(behaviour_fn))
+    }
+}
+
+impl<Behaviour> Deref for TestSwarm<Behaviour>
+where
+    Behaviour: NetworkBehaviour,
+{
+    type Target = Swarm<Behaviour>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<Behaviour> DerefMut for TestSwarm<Behaviour>
+where
+    Behaviour: NetworkBehaviour,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub struct TestEncapsulatedMessage(EncapsulatedMessage);
+
+impl TestEncapsulatedMessage {
+    pub fn new(payload: &[u8]) -> Self {
+        Self(
+            EncapsulatedMessage::new(&generate_valid_inputs(), PayloadType::Data, payload).unwrap(),
+        )
+    }
+
+    pub fn new_with_invalid_signature(payload: &[u8]) -> Self {
+        let mut self_instance = Self::new(payload);
+        self_instance.0.public_header_mut().signature = Signature::from([100u8; SIGNATURE_SIZE]);
+        self_instance
+    }
+
+    pub fn into_inner(self) -> EncapsulatedMessage {
+        self.0
+    }
+}
+
+fn generate_valid_inputs() -> EncapsulationInputs<3> {
+    EncapsulationInputs::new(
+        repeat_with(Ed25519PrivateKey::generate)
+            .take(3)
+            .map(|recipient_signing_key| {
+                let recipient_signing_pubkey = recipient_signing_key.public_key();
+                EncapsulationInput::new(
+                    Ed25519PrivateKey::generate(),
+                    &recipient_signing_pubkey,
+                    ProofOfQuota::from([0u8; PROOF_OF_QUOTA_SIZE]),
+                    ProofOfSelection::dummy(),
+                )
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    )
+    .unwrap()
+}
+
+/// Our test swarm generates random ed25519 identities. Hence, using `0`
+/// guarantees us that this value will always be smaller than the random
+/// identities.
+pub fn smallest_peer_id() -> PeerId {
+    PeerId::from_public_key(&PublicKey::try_from_bytes(&[0u8; 32]).unwrap().into())
+}
+
+/// Our test swarm generates random ed25519 identities. Hence, using `255`
+/// guarantees us that this value will always be larger than the random
+/// identities.
+pub fn largest_peer_id() -> PeerId {
+    PeerId::from_public_key(&PublicKey::try_from_bytes(&[255u8; 32]).unwrap().into())
+}
+
+impl Deref for TestEncapsulatedMessage {
+    type Target = EncapsulatedMessage;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for TestEncapsulatedMessage {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/nomos-blend/network/src/core/tests/utils.rs
+++ b/nomos-blend/network/src/core/tests/utils.rs
@@ -4,7 +4,6 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use futures::StreamExt;
 use libp2p::{
     identity::{ed25519::PublicKey, Keypair},
     PeerId, Swarm,
@@ -34,17 +33,6 @@ where
         BehaviourConstructor: FnOnce(Keypair) -> Behaviour,
     {
         Self(Swarm::new_ephemeral_tokio(behaviour_fn))
-    }
-}
-
-impl<Behaviour> TestSwarm<Behaviour>
-where
-    Behaviour: NetworkBehaviour,
-{
-    pub async fn loop_events(&mut self) {
-        loop {
-            let _ = self.0.select_next_some().await;
-        }
     }
 }
 

--- a/nomos-blend/network/src/core/tests/utils.rs
+++ b/nomos-blend/network/src/core/tests/utils.rs
@@ -4,6 +4,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
+use futures::StreamExt;
 use libp2p::{
     identity::{ed25519::PublicKey, Keypair},
     PeerId, Swarm,
@@ -33,6 +34,17 @@ where
         BehaviourConstructor: FnOnce(Keypair) -> Behaviour,
     {
         Self(Swarm::new_ephemeral_tokio(behaviour_fn))
+    }
+}
+
+impl<Behaviour> TestSwarm<Behaviour>
+where
+    Behaviour: NetworkBehaviour,
+{
+    pub async fn loop_events(&mut self) {
+        loop {
+            let _ = self.0.select_next_some().await;
+        }
     }
 }
 

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/bootstrapping.rs
@@ -10,9 +10,12 @@ use nomos_libp2p::SwarmEvent;
 use test_log::test;
 use tokio::{select, time::sleep};
 
-use crate::core::with_core::behaviour::{
-    tests::utils::{largest_peer_id, smallest_peer_id, BehaviourBuilder, SwarmExt as _, TestSwarm},
-    Event,
+use crate::core::{
+    tests::utils::{largest_peer_id, smallest_peer_id, TestSwarm},
+    with_core::behaviour::{
+        tests::utils::{BehaviourBuilder, SwarmExt as _},
+        Event,
+    },
 };
 
 #[test(tokio::test)]

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/bootstrapping.rs
@@ -184,7 +184,7 @@ async fn concurrent_incoming_connections() {
 
     // We check whether the dialer whose connection was dropped was also notified by
     // its behaviour that the dialed peer got disconnected.
-    assert!((dialer_1_dropped && dialer_1_notified) || (dialer_2_dropped && dialer_2_notified));
+    assert!((dialer_1_dropped && dialer_1_notified) ^ (dialer_2_dropped && dialer_2_notified));
 }
 
 #[test(tokio::test)]

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/bootstrapping.rs
@@ -8,7 +8,7 @@ use libp2p::{
 use libp2p_swarm_test::SwarmExt as _;
 use nomos_libp2p::SwarmEvent;
 use test_log::test;
-use tokio::{join, select, spawn, time::sleep};
+use tokio::{select, time::sleep};
 
 use crate::core::{
     tests::utils::{largest_peer_id, smallest_peer_id, TestSwarm},
@@ -122,7 +122,6 @@ async fn incoming_attempt_with_max_negotiated_peering_degree() {
 async fn concurrent_incoming_connections() {
     let mut listening_swarm =
         TestSwarm::new(|id| BehaviourBuilder::default().with_identity(id).build());
-    let listening_swarm_peer_id = *listening_swarm.local_peer_id();
     let mut dialer_swarm_1 =
         TestSwarm::new(|id| BehaviourBuilder::default().with_identity(id).build());
     let mut dialer_swarm_2 =
@@ -130,21 +129,9 @@ async fn concurrent_incoming_connections() {
 
     let (listening_address, _) = listening_swarm.listen().await;
 
-    // We poll the listening swarm to advance it.
-    spawn(async move {
-        loop {
-            if let SwarmEvent::Behaviour(Event::PeerDisconnected(_, _)) =
-                listening_swarm.select_next_some().await
-            {
-                panic!("Should not generate a `PeerDisconnected` event for a peer that went above our peering degree.");
-            }
-        }
-    });
-
-    let _ = join!(
-        dialer_swarm_1.dial_and_wait(listening_address.clone()),
-        dialer_swarm_2.dial_and_wait(listening_address.clone())
-    );
+    // Dial concurrently before we poll the listening swarm.
+    dialer_swarm_1.dial(listening_address.clone()).unwrap();
+    dialer_swarm_2.dial(listening_address).unwrap();
 
     let mut dialer_1_dropped = false;
     let mut dialer_1_notified = false;
@@ -158,15 +145,21 @@ async fn concurrent_incoming_connections() {
             () = sleep(Duration::from_secs(11)) => {
                 break;
             }
+            listening_swarm_event = listening_swarm.select_next_some() => {
+                // We check that the listening swarm never generates a `PeerDisconnected` event because it knows the dropped connection is meant to be ignored.
+                if let SwarmEvent::Behaviour(Event::PeerDisconnected(_, _)) = listening_swarm_event {
+                    panic!("Should not generate a `PeerDisconnected` event for a peer that went above our peering degree.");
+                }
+            }
             dialer_swarm_1_event = dialer_swarm_1.select_next_some() => {
                 match dialer_swarm_1_event {
                     SwarmEvent::ConnectionClosed { endpoint, peer_id, .. } => {
                         assert!(!dialer_2_dropped);
-                        assert_eq!(peer_id, listening_swarm_peer_id);
+                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
                         assert!(endpoint.is_dialer());
                         dialer_1_dropped = true;
                     }
-                    SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) if peer_id == listening_swarm_peer_id => {
+                    SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) if peer_id == *listening_swarm.local_peer_id() => {
                         dialer_1_notified = true;
                     }
                     _ => {}
@@ -176,11 +169,11 @@ async fn concurrent_incoming_connections() {
                 match dialer_swarm_2_event {
                     SwarmEvent::ConnectionClosed { endpoint, peer_id, .. } => {
                         assert!(!dialer_1_dropped);
-                        assert_eq!(peer_id, listening_swarm_peer_id);
+                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
                         assert!(endpoint.is_dialer());
                         dialer_2_dropped = true;
                     }
-                    SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) if peer_id == listening_swarm_peer_id => {
+                    SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) if peer_id == *listening_swarm.local_peer_id() => {
                         dialer_2_notified = true;
                     }
                     _ => {}
@@ -278,10 +271,8 @@ async fn concurrent_outgoing_connections() {
         TestSwarm::new(|id| BehaviourBuilder::default().with_identity(id).build());
     let mut listening_swarm_1 =
         TestSwarm::new(|id| BehaviourBuilder::default().with_identity(id).build());
-    let listening_swarm_1_peer_id = *listening_swarm_1.local_peer_id();
     let mut listening_swarm_2 =
         TestSwarm::new(|id| BehaviourBuilder::default().with_identity(id).build());
-    let listening_swarm_2_peer_id = *listening_swarm_2.local_peer_id();
 
     let (listening_address_1, _) = listening_swarm_1.listen().await;
     let (listening_address_2, _) = listening_swarm_2.listen().await;
@@ -289,28 +280,10 @@ async fn concurrent_outgoing_connections() {
     dialing_swarm.dial(listening_address_1).unwrap();
     dialing_swarm.dial(listening_address_2).unwrap();
 
-    // We poll the listening swarms to advance them.
-    spawn(async move {
-        loop {
-            if let SwarmEvent::Behaviour(Event::PeerDisconnected(_, _)) =
-                listening_swarm_1.select_next_some().await
-            {
-                panic!("Should not generate a `PeerDisconnected` event for a peer that went above our peering degree.");
-            }
-        }
-    });
-    spawn(async move {
-        loop {
-            if let SwarmEvent::Behaviour(Event::PeerDisconnected(_, _)) =
-                listening_swarm_2.select_next_some().await
-            {
-                panic!("Should not generate a `PeerDisconnected` event for a peer that went above our peering degree.");
-            }
-        }
-    });
-
     let mut listener_1_dropped = false;
+    let mut listener_1_notified = false;
     let mut listener_2_dropped = false;
+    let mut listener_2_notified = false;
     loop {
         select! {
             // We make sure that after 11 seconds one of the two connections is dropped (the swarm used in the tests uses a default timeout of 10s).
@@ -320,20 +293,35 @@ async fn concurrent_outgoing_connections() {
                 break;
             },
             dialing_swarm_event = dialing_swarm.select_next_some() => {
-                match dialing_swarm_event {
+                // We check that the dialing swarm never generates a `PeerDisconnected` event because it knows the dropped connection is meant to be ignored.
+                if let SwarmEvent::Behaviour(Event::PeerDisconnected(_, _)) = dialing_swarm_event {
+                    panic!("Should not generate a `PeerDisconnected` event for a peer that went above our peering degree.");
+                }
+            }
+            listener_swarm_1_event = listening_swarm_1.select_next_some() => {
+                match listener_swarm_1_event {
                     SwarmEvent::ConnectionClosed { endpoint, peer_id, .. } => {
-                        assert!(endpoint.is_dialer());
-                        if peer_id == listening_swarm_1_peer_id {
-                            assert!(!listener_2_dropped);
-                            listener_1_dropped = true;
-                        } else if peer_id == listening_swarm_2_peer_id {
-                            assert!(!listener_1_dropped);
-                            listener_2_dropped = true;
-                        }
+                        assert!(!listener_2_dropped);
+                        assert_eq!(peer_id, *dialing_swarm.local_peer_id());
+                        assert!(endpoint.is_listener());
+                        listener_1_dropped = true;
                     }
-                    // We check that the dialing swarm never generates a `PeerDisconnected` event because it knows the dropped connection is meant to be ignored.
-                    SwarmEvent::Behaviour(Event::PeerDisconnected(_, _)) => {
-                        panic!("Should not generate a `PeerDisconnected` event for a peer that went above our peering degree.");
+                    SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) if peer_id == *dialing_swarm.local_peer_id() => {
+                        listener_1_notified = true;
+                    }
+                    _ => {}
+                }
+            }
+            listener_swarm_2_event = listening_swarm_2.select_next_some() => {
+                match listener_swarm_2_event {
+                    SwarmEvent::ConnectionClosed { endpoint, peer_id, .. } => {
+                        assert!(!listener_1_dropped);
+                        assert_eq!(peer_id, *dialing_swarm.local_peer_id());
+                        assert!(endpoint.is_listener());
+                        listener_2_dropped = true;
+                    }
+                    SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) if peer_id == *dialing_swarm.local_peer_id() => {
+                        listener_2_notified = true;
                     }
                     _ => {}
                 }
@@ -341,7 +329,11 @@ async fn concurrent_outgoing_connections() {
         }
     }
 
-    assert!(listener_2_dropped ^ listener_2_dropped);
+    // We check whether the listener whose connection was dropped was also notified
+    // by its behaviour that the dialed peer got disconnected.
+    assert!(
+        (listener_1_dropped && listener_1_notified) || (listener_2_dropped && listener_2_notified)
+    );
 }
 
 #[test(tokio::test)]

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
@@ -6,12 +6,12 @@ use nomos_libp2p::SwarmEvent;
 use test_log::test;
 use tokio::{select, time::sleep};
 
-use crate::core::with_core::behaviour::{
-    tests::utils::{
-        BehaviourBuilder, IntervalProviderBuilder, SwarmExt as _, TestEncapsulatedMessage,
-        TestSwarm,
+use crate::core::{
+    tests::utils::{TestEncapsulatedMessage, TestSwarm},
+    with_core::behaviour::{
+        tests::utils::{BehaviourBuilder, IntervalProviderBuilder, SwarmExt as _},
+        Event, NegotiatedPeerState, SpamReason,
     },
-    Event, NegotiatedPeerState, SpamReason,
 };
 
 #[test(tokio::test)]

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/message_handling.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/message_handling.rs
@@ -8,12 +8,15 @@ use test_log::test;
 use tokio::{select, time::sleep};
 
 use crate::{
-    core::with_core::{
-        behaviour::{
-            tests::utils::{BehaviourBuilder, SwarmExt as _, TestEncapsulatedMessage, TestSwarm},
-            Event, NegotiatedPeerState, SpamReason,
+    core::{
+        tests::utils::{TestEncapsulatedMessage, TestSwarm},
+        with_core::{
+            behaviour::{
+                tests::utils::{BehaviourBuilder, SwarmExt as _},
+                Event, NegotiatedPeerState, SpamReason,
+            },
+            error::Error,
         },
-        error::Error,
     },
     message::ValidateMessagePublicHeader as _,
 };

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/utils.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/utils.rs
@@ -1,24 +1,10 @@
-use core::{
-    fmt::Debug,
-    iter::repeat_with,
-    ops::{Deref, DerefMut, RangeInclusive},
-    time::Duration,
-};
+use core::{fmt::Debug, ops::RangeInclusive, time::Duration};
 use std::collections::{HashMap, VecDeque};
 
 use async_trait::async_trait;
 use futures::{select, Stream, StreamExt as _};
-use libp2p::{
-    identity::{ed25519::PublicKey, Keypair},
-    PeerId, Swarm,
-};
+use libp2p::{identity::Keypair, PeerId, Swarm};
 use libp2p_swarm_test::SwarmExt as _;
-use nomos_blend_message::{
-    crypto::{Ed25519PrivateKey, ProofOfQuota, ProofOfSelection, Signature, SIGNATURE_SIZE},
-    input::{EncapsulationInput, EncapsulationInputs},
-    PayloadType,
-};
-use nomos_blend_scheduling::EncapsulatedMessage;
 use nomos_libp2p::{NetworkBehaviour, SwarmEvent};
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
@@ -111,109 +97,6 @@ impl BehaviourBuilder {
             peering_degree: self.peering_degree.unwrap_or(1..=1),
             local_peer_id,
         }
-    }
-}
-
-pub struct TestSwarm<Behaviour>(Swarm<Behaviour>)
-where
-    Behaviour: NetworkBehaviour;
-
-impl<Behaviour> TestSwarm<Behaviour>
-where
-    Behaviour: NetworkBehaviour<ToSwarm: Debug> + Send,
-{
-    pub fn new<BehaviourConstructor>(behaviour_fn: BehaviourConstructor) -> Self
-    where
-        BehaviourConstructor: FnOnce(Keypair) -> Behaviour,
-    {
-        Self(Swarm::new_ephemeral_tokio(behaviour_fn))
-    }
-}
-
-impl<Behaviour> Deref for TestSwarm<Behaviour>
-where
-    Behaviour: NetworkBehaviour,
-{
-    type Target = Swarm<Behaviour>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<Behaviour> DerefMut for TestSwarm<Behaviour>
-where
-    Behaviour: NetworkBehaviour,
-{
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-pub struct TestEncapsulatedMessage(EncapsulatedMessage);
-
-impl TestEncapsulatedMessage {
-    pub fn new(payload: &[u8]) -> Self {
-        Self(
-            EncapsulatedMessage::new(&generate_valid_inputs(), PayloadType::Data, payload).unwrap(),
-        )
-    }
-
-    pub fn new_with_invalid_signature(payload: &[u8]) -> Self {
-        let mut self_instance = Self::new(payload);
-        self_instance.0.public_header_mut().signature = Signature::from([100u8; SIGNATURE_SIZE]);
-        self_instance
-    }
-
-    pub fn into_inner(self) -> EncapsulatedMessage {
-        self.0
-    }
-}
-
-fn generate_valid_inputs() -> EncapsulationInputs<3> {
-    EncapsulationInputs::new(
-        repeat_with(Ed25519PrivateKey::generate)
-            .take(3)
-            .map(|recipient_signing_key| {
-                let recipient_signing_pubkey = recipient_signing_key.public_key();
-                EncapsulationInput::new(
-                    Ed25519PrivateKey::generate(),
-                    &recipient_signing_pubkey,
-                    ProofOfQuota::dummy(),
-                    ProofOfSelection::dummy(),
-                )
-            })
-            .collect::<Vec<_>>()
-            .into_boxed_slice(),
-    )
-    .unwrap()
-}
-
-/// Our test swarm generates random ed25519 identities. Hence, using `0`
-/// guarantees us that this value will always be smaller than the random
-/// identities.
-pub fn smallest_peer_id() -> PeerId {
-    PeerId::from_public_key(&PublicKey::try_from_bytes(&[0u8; 32]).unwrap().into())
-}
-
-/// Our test swarm generates random ed25519 identities. Hence, using `255`
-/// guarantees us that this value will always be larger than the random
-/// identities.
-pub fn largest_peer_id() -> PeerId {
-    PeerId::from_public_key(&PublicKey::try_from_bytes(&[255u8; 32]).unwrap().into())
-}
-
-impl Deref for TestEncapsulatedMessage {
-    type Target = EncapsulatedMessage;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for TestEncapsulatedMessage {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/nomos-blend/network/src/core/with_edge/behaviour/mod.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/mod.rs
@@ -25,6 +25,9 @@ use crate::{
 
 mod handler;
 
+#[cfg(test)]
+mod tests;
+
 const LOG_TARGET: &str = "blend::network::core::edge::behaviour";
 
 #[derive(Debug)]

--- a/nomos-blend/network/src/core/with_edge/behaviour/mod.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/mod.rs
@@ -81,11 +81,13 @@ impl Behaviour {
         let Ok(deserialized_encapsulated_message) =
             deserialize_encapsulated_message(serialized_message)
         else {
+            tracing::trace!(target: LOG_TARGET, "Failed to deserialize received message. Ignoring...");
             return;
         };
 
         let Ok(validated_message) = deserialized_encapsulated_message.validate_public_header()
         else {
+            tracing::trace!(target: LOG_TARGET, "Failed to validate public header of received message. Ignoring...");
             return;
         };
 

--- a/nomos-blend/network/src/core/with_edge/behaviour/mod.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/mod.rs
@@ -119,6 +119,12 @@ impl Behaviour {
             return;
         }
         tracing::debug!(target: LOG_TARGET, "Connection {connection:?} has been negotiated.");
+        self.events.push_back(ToSwarm::NotifyHandler {
+            peer_id: connection.0,
+            handler: NotifyHandler::One(connection.1),
+            event: Either::Left(FromBehaviour::StartReceiving),
+        });
+        self.try_wake();
         self.upgraded_edge_peers.insert(connection);
     }
 }

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
@@ -1,10 +1,100 @@
+use futures::StreamExt as _;
+use libp2p::swarm::dummy;
+use libp2p_stream::{Behaviour as StreamBehaviour, OpenStreamError};
+use libp2p_swarm_test::SwarmExt as _;
+use nomos_libp2p::SwarmEvent;
 use test_log::test;
+use tokio::select;
+
+use crate::{
+    core::{
+        tests::utils::TestSwarm,
+        with_edge::behaviour::{Behaviour, Event},
+    },
+    PROTOCOL_NAME,
+};
 
 #[test(tokio::test)]
-async fn edge_peer_not_supporting_blend() {}
+async fn edge_peer_not_supporting_blend() {
+    let mut dummy_swarm = TestSwarm::new(|_| dummy::Behaviour);
+    let mut blend_swarm =
+        TestSwarm::new(|_| Behaviour::with_edge_peer(*dummy_swarm.local_peer_id()));
+
+    let (blend_address, _) = blend_swarm.listen().await;
+    dummy_swarm.dial(blend_address).unwrap();
+
+    let mut events_to_match = 2u8;
+    loop {
+        select! {
+            core_event = blend_swarm.select_next_some() => {
+                if let SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } = core_event {
+                    assert_eq!(peer_id, *dummy_swarm.local_peer_id());
+                    assert!(endpoint.is_listener());
+                    events_to_match -= 1;
+                }
+            }
+            dummy_event = dummy_swarm.select_next_some() => {
+                if let SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } = dummy_event {
+                    assert_eq!(peer_id, *blend_swarm.local_peer_id());
+                    assert!(endpoint.is_dialer());
+                    events_to_match -= 1;
+                }
+            }
+        }
+        if events_to_match == 0 {
+            break;
+        }
+    }
+}
 
 #[test(tokio::test)]
-async fn peer_not_an_edge_node() {}
+async fn non_edge_peer() {
+    let mut other_core_swarm = TestSwarm::new(|_| StreamBehaviour::new());
+    let mut blend_swarm =
+        TestSwarm::new(|_| Behaviour::with_edge_peer(*other_core_swarm.local_peer_id()));
+
+    let (blend_address, _) = blend_swarm.listen().await;
+    other_core_swarm.dial(blend_address).unwrap();
+
+    let mut events_to_match = 3u8;
+    loop {
+        select! {
+            core_event = blend_swarm.select_next_some() => {
+                match core_event {
+                    SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } => {
+                        assert_eq!(peer_id, *other_core_swarm.local_peer_id());
+                        assert!(endpoint.is_listener());
+                        events_to_match -= 1;
+                    }
+                    SwarmEvent::Behaviour(Event::Message(_)) => {
+                        panic!("Core->edge behaviour should not be able to receive messages from non-edge nodes.");
+                    }
+                    _ => {}
+                }
+            }
+            other_core_swarm_event = other_core_swarm.select_next_some() => {
+                match other_core_swarm_event {
+                    SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                        assert_eq!(peer_id, *blend_swarm.local_peer_id());
+                        // Upgrading the protocol should fail since the core node returns a dummy handler for non-edge peers.
+                        let stream_control_res = other_core_swarm.behaviour_mut().new_control().open_stream(*blend_swarm.local_peer_id(), PROTOCOL_NAME).await;
+                        assert!(matches!(stream_control_res, Err(OpenStreamError::UnsupportedProtocol(_))));
+                        events_to_match -= 1;
+                    }
+                    SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } => {
+                        assert_eq!(peer_id, *blend_swarm.local_peer_id());
+                        assert!(endpoint.is_dialer());
+                        events_to_match -= 1;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if events_to_match == 0 {
+            break;
+        }
+    }
+}
 
 #[test(tokio::test)]
 async fn incoming_connection_with_maximum_peering_degree() {}

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
@@ -1,0 +1,16 @@
+use test_log::test;
+
+#[test(tokio::test)]
+async fn edge_peer_not_supporting_blend() {}
+
+#[test(tokio::test)]
+async fn peer_not_an_edge_node() {}
+
+#[test(tokio::test)]
+async fn incoming_connection_with_maximum_peering_degree() {}
+
+#[test(tokio::test)]
+async fn concurrent_incoming_connection_and_maximum_peering_degree_reached() {}
+
+#[test(tokio::test)]
+async fn outgoing_connection_to_edge_peer() {}

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
@@ -23,7 +23,7 @@ async fn edge_peer_not_supporting_blend() {
     let mut blend_swarm = TestSwarm::new(|_| {
         BehaviourBuilder::default()
             // Add random peer to membership so the dummy swarm is considered an edge node.
-            .with_edge_peer_membership(PeerId::random())
+            .with_core_peer_membership(PeerId::random())
             .build()
     });
 
@@ -59,7 +59,7 @@ async fn non_edge_peer() {
     let mut other_core_swarm = TestSwarm::new(|_| StreamBehaviour::new());
     let mut blend_swarm = TestSwarm::new(|_| {
         BehaviourBuilder::default()
-            .with_edge_peer_membership(*other_core_swarm.local_peer_id())
+            .with_core_peer_membership(*other_core_swarm.local_peer_id())
             .build()
     });
 
@@ -84,7 +84,7 @@ async fn incoming_connection_with_maximum_peering_degree() {
     let mut blend_swarm = TestSwarm::new(|_| {
         BehaviourBuilder::default()
             // Add random peer to membership so the two swarms are considered edge nodes.
-            .with_edge_peer_membership(PeerId::random())
+            .with_core_peer_membership(PeerId::random())
             // We increase the timeout to send a message so that the swarm will close the rejected
             // connection before the behaviour closes the second connection due to inactivity.
             .with_timeout(Duration::from_secs(13))
@@ -142,7 +142,7 @@ async fn concurrent_incoming_connection_and_maximum_peering_degree_reached() {
         BehaviourBuilder::default()
             .with_max_incoming_connections(1)
             .with_timeout(Duration::from_secs(13))
-            .with_edge_peer_membership(PeerId::random())
+            .with_core_peer_membership(PeerId::random())
             .build()
     });
     let listening_swarm_peer_id = *listening_swarm.local_peer_id();
@@ -211,7 +211,7 @@ async fn concurrent_incoming_connection_and_maximum_peering_degree_reached() {
 async fn outgoing_connection_to_edge_peer() {
     let mut core_swarm = TestSwarm::new(|_| {
         BehaviourBuilder::default()
-            .with_edge_peer_membership(PeerId::random())
+            .with_core_peer_membership(PeerId::random())
             .build()
     });
     let mut edge_swarm = TestSwarm::new(|_| StreamBehaviour::new());

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
@@ -1,15 +1,20 @@
-use futures::StreamExt as _;
-use libp2p::swarm::dummy;
+use core::time::Duration;
+
+use futures::{AsyncWriteExt as _, StreamExt as _};
+use libp2p::{swarm::dummy, PeerId};
 use libp2p_stream::{Behaviour as StreamBehaviour, OpenStreamError};
 use libp2p_swarm_test::SwarmExt as _;
 use nomos_libp2p::SwarmEvent;
 use test_log::test;
-use tokio::select;
+use tokio::{select, spawn, time::sleep};
 
 use crate::{
     core::{
         tests::utils::TestSwarm,
-        with_edge::behaviour::{Behaviour, Event},
+        with_edge::behaviour::{
+            tests::utils::{BehaviourBuilder, StreamBehaviourExt as _},
+            Event,
+        },
     },
     PROTOCOL_NAME,
 };
@@ -17,8 +22,12 @@ use crate::{
 #[test(tokio::test)]
 async fn edge_peer_not_supporting_blend() {
     let mut dummy_swarm = TestSwarm::new(|_| dummy::Behaviour);
-    let mut blend_swarm =
-        TestSwarm::new(|_| Behaviour::with_edge_peer(*dummy_swarm.local_peer_id()));
+    let mut blend_swarm = TestSwarm::new(|_| {
+        BehaviourBuilder::default()
+            // Add random peer to membership so the dummy swarm is considered an edge node.
+            .with_edge_peer_membership(PeerId::random())
+            .build()
+    });
 
     let (blend_address, _) = blend_swarm.listen().await;
     dummy_swarm.dial(blend_address).unwrap();
@@ -50,8 +59,11 @@ async fn edge_peer_not_supporting_blend() {
 #[test(tokio::test)]
 async fn non_edge_peer() {
     let mut other_core_swarm = TestSwarm::new(|_| StreamBehaviour::new());
-    let mut blend_swarm =
-        TestSwarm::new(|_| Behaviour::with_edge_peer(*other_core_swarm.local_peer_id()));
+    let mut blend_swarm = TestSwarm::new(|_| {
+        BehaviourBuilder::default()
+            .with_edge_peer_membership(*other_core_swarm.local_peer_id())
+            .build()
+    });
 
     let (blend_address, _) = blend_swarm.listen().await;
     other_core_swarm.dial(blend_address).unwrap();
@@ -97,10 +109,180 @@ async fn non_edge_peer() {
 }
 
 #[test(tokio::test)]
-async fn incoming_connection_with_maximum_peering_degree() {}
+async fn incoming_connection_with_maximum_peering_degree() {
+    let mut edge_swarm_1 = TestSwarm::new(|_| StreamBehaviour::new());
+    let mut edge_swarm_2 = TestSwarm::new(|_| StreamBehaviour::new());
+    let mut blend_swarm = TestSwarm::new(|_| {
+        BehaviourBuilder::default()
+            // Add random peer to membership so the two swarms are considered edge nodes.
+            .with_edge_peer_membership(PeerId::random())
+            // We increase the timeout to send a message so that the swarm will close the rejected
+            // connection before the behaviour closes the second connection due to inactivity.
+            .with_timeout(Duration::from_secs(13))
+            .with_max_incoming_connections(1)
+            .build()
+    });
+
+    let (blend_swarm_address, _) = blend_swarm.listen().with_memory_addr_external().await;
+
+    // We wait that the first connection is established and upgraded.
+    edge_swarm_1
+        .connect_and_upgrade_to_blend(&mut blend_swarm)
+        .await;
+
+    // Then we perform the second dial.
+    edge_swarm_2.dial(blend_swarm_address).unwrap();
+
+    let mut edge_swarm_connection_2_closed = false;
+    // We verify that the additional connection is closed, and that the old one is
+    // kept alive (since we set a timeout of 13 seconds while the default swarm has
+    // a timeout of 10 seconds).
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(12)) => {
+                break;
+            }
+             edge_swarm_1_event = edge_swarm_1.select_next_some() => {
+                if let SwarmEvent::ConnectionClosed { .. } = edge_swarm_1_event {
+                    panic!("Connection with edge swarm 1 should not be closed for the duration of the test.");
+                }
+            }
+            edge_swarm_2_event = edge_swarm_2.select_next_some() => {
+                if let SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } = edge_swarm_2_event {
+                    assert_eq!(peer_id, *blend_swarm.local_peer_id());
+                    assert!(endpoint.is_dialer());
+                    edge_swarm_connection_2_closed = true;
+                }
+            }
+            blend_swarm_event = blend_swarm.select_next_some() => {
+                if let SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } = blend_swarm_event {
+                    assert_eq!(peer_id, *edge_swarm_2.local_peer_id());
+                    assert!(endpoint.is_listener());
+                }
+            }
+        }
+    }
+
+    assert!(edge_swarm_connection_2_closed);
+}
 
 #[test(tokio::test)]
-async fn concurrent_incoming_connection_and_maximum_peering_degree_reached() {}
+async fn concurrent_incoming_connection_and_maximum_peering_degree_reached() {
+    let mut listening_swarm = TestSwarm::new(|_| {
+        BehaviourBuilder::default()
+            .with_max_incoming_connections(1)
+            .with_timeout(Duration::from_secs(13))
+            .with_edge_peer_membership(PeerId::random())
+            .build()
+    });
+    let listening_swarm_peer_id = *listening_swarm.local_peer_id();
+    let mut dialer_swarm_1 = TestSwarm::new(|_| StreamBehaviour::new());
+    let mut dialer_swarm_2 = TestSwarm::new(|_| StreamBehaviour::new());
+
+    let (listening_address, _) = listening_swarm.listen().await;
+
+    // Dial concurrently before we poll the listening swarm.
+    dialer_swarm_1.dial(listening_address.clone()).unwrap();
+    let dialer_1_control = dialer_swarm_1.behaviour_mut().new_control();
+    dialer_swarm_2.dial(listening_address).unwrap();
+    let dialer_2_control = dialer_swarm_2.behaviour_mut().new_control();
+
+    let mut dialer_1_dropped = false;
+    let mut dialer_2_dropped = false;
+    loop {
+        select! {
+            // We make sure that after 12 seconds one of the two connections is dropped (the swarm used in the tests uses a default timeout of 10s and we increased the keepalive timeout for the tested behaviour to 13s).
+            // We cannot prevent both connections from being upgraded, but we can test that one of the two is dropped once the listener realized it is above the maximum peering degree.
+            // We do not know which one beforehand because they are started in parallel.
+            () = sleep(Duration::from_secs(12)) => {
+                break;
+            }
+            _ = listening_swarm.select_next_some() => {}
+            dialer_swarm_1_event = dialer_swarm_1.select_next_some() => {
+                match dialer_swarm_1_event {
+                    SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
+                        let mut dialer_control = dialer_1_control.clone();
+                        spawn(async move {let _ = dialer_control.open_stream(listening_swarm_peer_id, PROTOCOL_NAME).await.unwrap().write(b"").await.unwrap();});
+                    }
+                    SwarmEvent::ConnectionClosed { endpoint, peer_id, .. } => {
+                        assert!(!dialer_2_dropped);
+                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
+                        assert!(endpoint.is_dialer());
+                        dialer_1_dropped = true;
+                    }
+                    _ => {}
+                }
+            }
+            dialer_swarm_2_event = dialer_swarm_2.select_next_some() => {
+                match dialer_swarm_2_event {
+                    SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
+                        let mut dialer_control = dialer_2_control.clone();
+                        spawn(async move {let _ = dialer_control.open_stream(listening_swarm_peer_id, PROTOCOL_NAME).await.unwrap().write(b"").await.unwrap();});
+                    }
+                    SwarmEvent::ConnectionClosed { endpoint, peer_id, .. } => {
+                        assert!(!dialer_1_dropped);
+                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
+                        assert!(endpoint.is_dialer());
+                        dialer_2_dropped = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    assert!(dialer_1_dropped ^ dialer_2_dropped);
+}
 
 #[test(tokio::test)]
-async fn outgoing_connection_to_edge_peer() {}
+async fn outgoing_connection_to_edge_peer() {
+    let mut core_swarm = TestSwarm::new(|_| {
+        BehaviourBuilder::default()
+            .with_edge_peer_membership(PeerId::random())
+            .build()
+    });
+    let mut edge_swarm = TestSwarm::new(|_| StreamBehaviour::new());
+    let edge_swarm_control = edge_swarm.behaviour_mut().new_control();
+
+    let (edge_swarm_address, _) = edge_swarm.listen().await;
+    core_swarm.dial(edge_swarm_address).unwrap();
+
+    let mut core_swarm_ready = false;
+    let mut edge_swarm_ready = false;
+    loop {
+        // We don't know which swarm will get notified first, so we need to check the
+        // same condition in both cases.
+        select! {
+            edge_swarm_event = edge_swarm.select_next_some() => {
+                if let SwarmEvent::ConnectionEstablished { peer_id, .. } = edge_swarm_event {
+                    assert_eq!(peer_id, *core_swarm.local_peer_id());
+                    assert!(!edge_swarm_ready);
+                    if core_swarm_ready {
+                        let mut control = edge_swarm_control.clone();
+                        let stream_control_res = control.open_stream(*core_swarm.local_peer_id(), PROTOCOL_NAME).await;
+                        // Since we use a dummy handler for outgoing connections to edge nodes, the stream upgrade should fail.
+                        assert!(matches!(stream_control_res, Err(OpenStreamError::UnsupportedProtocol(_))));
+                        break;
+                    }
+                    edge_swarm_ready = true;
+                }
+            }
+            core_swarm_event = core_swarm.select_next_some() => {
+                if let SwarmEvent::ConnectionEstablished { peer_id, .. } = core_swarm_event {
+                    assert_eq!(peer_id, *edge_swarm.local_peer_id());
+                    assert!(!core_swarm_ready);
+                    if edge_swarm_ready {
+                        let mut control = edge_swarm_control.clone();
+                        let stream_control_res = control.open_stream(*core_swarm.local_peer_id(), PROTOCOL_NAME).await;
+                        // Since we use a dummy handler for outgoing connections to edge nodes, the stream upgrade should fail.
+                        assert!(matches!(stream_control_res, Err(OpenStreamError::UnsupportedProtocol(_))));
+                        break;
+                    }
+                    core_swarm_ready = true;
+                }
+            }
+        }
+    }
+}

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
@@ -94,7 +94,7 @@ async fn incoming_connection_with_maximum_peering_degree() {
     blend_swarm.listen().with_memory_addr_external().await;
 
     // We wait that the first connection is established and upgraded.
-    edge_swarm_1
+    let _ = edge_swarm_1
         .connect_and_upgrade_to_blend(&mut blend_swarm)
         .await;
 

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use futures::StreamExt as _;
 use libp2p::{swarm::dummy, PeerId, Stream};
 use libp2p_stream::{Behaviour as StreamBehaviour, OpenStreamError};
-use libp2p_swarm_test::SwarmExt;
+use libp2p_swarm_test::SwarmExt as _;
 use nomos_libp2p::SwarmEvent;
 use test_log::test;
 use tokio::{select, spawn, time::sleep};

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
@@ -1,20 +1,17 @@
 use core::time::Duration;
 
-use futures::{AsyncWriteExt as _, StreamExt as _};
+use futures::{AsyncWriteExt as _, FutureExt, StreamExt as _};
 use libp2p::{swarm::dummy, PeerId};
 use libp2p_stream::{Behaviour as StreamBehaviour, OpenStreamError};
-use libp2p_swarm_test::SwarmExt as _;
+use libp2p_swarm_test::SwarmExt;
 use nomos_libp2p::SwarmEvent;
 use test_log::test;
-use tokio::{select, spawn, time::sleep};
+use tokio::{join, select, spawn, time::sleep};
 
 use crate::{
     core::{
         tests::utils::TestSwarm,
-        with_edge::behaviour::{
-            tests::utils::{BehaviourBuilder, StreamBehaviourExt as _},
-            Event,
-        },
+        with_edge::behaviour::tests::utils::{BehaviourBuilder, StreamBehaviourExt as _},
     },
     PROTOCOL_NAME,
 };
@@ -29,8 +26,8 @@ async fn edge_peer_not_supporting_blend() {
             .build()
     });
 
-    let (blend_address, _) = blend_swarm.listen().await;
-    dummy_swarm.dial(blend_address).unwrap();
+    blend_swarm.listen().with_memory_addr_external().await;
+    dummy_swarm.connect(&mut blend_swarm).await;
 
     let mut events_to_match = 2u8;
     loop {
@@ -65,47 +62,18 @@ async fn non_edge_peer() {
             .build()
     });
 
-    let (blend_address, _) = blend_swarm.listen().await;
-    other_core_swarm.dial(blend_address).unwrap();
+    blend_swarm.listen().with_memory_addr_external().await;
+    other_core_swarm.connect(&mut blend_swarm).await;
 
-    let mut events_to_match = 3u8;
-    loop {
-        select! {
-            core_event = blend_swarm.select_next_some() => {
-                match core_event {
-                    SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } => {
-                        assert_eq!(peer_id, *other_core_swarm.local_peer_id());
-                        assert!(endpoint.is_listener());
-                        events_to_match -= 1;
-                    }
-                    SwarmEvent::Behaviour(Event::Message(_)) => {
-                        panic!("Core->edge behaviour should not be able to receive messages from non-edge nodes.");
-                    }
-                    _ => {}
-                }
-            }
-            other_core_swarm_event = other_core_swarm.select_next_some() => {
-                match other_core_swarm_event {
-                    SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-                        assert_eq!(peer_id, *blend_swarm.local_peer_id());
-                        // Upgrading the protocol should fail since the core node returns a dummy handler for non-edge peers.
-                        let stream_control_res = other_core_swarm.behaviour_mut().new_control().open_stream(*blend_swarm.local_peer_id(), PROTOCOL_NAME).await;
-                        assert!(matches!(stream_control_res, Err(OpenStreamError::UnsupportedProtocol(_))));
-                        events_to_match -= 1;
-                    }
-                    SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } => {
-                        assert_eq!(peer_id, *blend_swarm.local_peer_id());
-                        assert!(endpoint.is_dialer());
-                        events_to_match -= 1;
-                    }
-                    _ => {}
-                }
-            }
-        }
-        if events_to_match == 0 {
-            break;
-        }
-    }
+    let stream_control_res = other_core_swarm
+        .behaviour_mut()
+        .new_control()
+        .open_stream(*blend_swarm.local_peer_id(), PROTOCOL_NAME)
+        .await;
+    assert!(matches!(
+        stream_control_res,
+        Err(OpenStreamError::UnsupportedProtocol(_))
+    ));
 }
 
 #[test(tokio::test)]
@@ -123,7 +91,7 @@ async fn incoming_connection_with_maximum_peering_degree() {
             .build()
     });
 
-    let (blend_swarm_address, _) = blend_swarm.listen().with_memory_addr_external().await;
+    blend_swarm.listen().with_memory_addr_external().await;
 
     // We wait that the first connection is established and upgraded.
     edge_swarm_1
@@ -131,7 +99,7 @@ async fn incoming_connection_with_maximum_peering_degree() {
         .await;
 
     // Then we perform the second dial.
-    edge_swarm_2.dial(blend_swarm_address).unwrap();
+    edge_swarm_2.connect(&mut blend_swarm).await;
 
     let mut edge_swarm_connection_2_closed = false;
     // We verify that the additional connection is closed, and that the old one is
@@ -181,59 +149,58 @@ async fn concurrent_incoming_connection_and_maximum_peering_degree_reached() {
 
     let (listening_address, _) = listening_swarm.listen().await;
 
-    // Dial concurrently before we poll the listening swarm.
-    dialer_swarm_1.dial(listening_address.clone()).unwrap();
-    let dialer_1_control = dialer_swarm_1.behaviour_mut().new_control();
-    dialer_swarm_2.dial(listening_address).unwrap();
-    let dialer_2_control = dialer_swarm_2.behaviour_mut().new_control();
+    // We poll the listening swarm to advance it.
+    spawn(async move {
+        listening_swarm.loop_events().await;
+    });
 
-    let mut dialer_1_dropped = false;
-    let mut dialer_2_dropped = false;
+    let _ = join!(
+        dialer_swarm_1.dial_and_wait(listening_address.clone()),
+        dialer_swarm_2.dial_and_wait(listening_address.clone())
+    );
+
+    let mut dialer_swarm_1_control = dialer_swarm_1.behaviour_mut().new_control();
+    let mut dialer_swarm_2_control = dialer_swarm_2.behaviour_mut().new_control();
+    let (mut dialer_swarm_1_stream, mut dialer_swarm_2_stream) = join!(
+        dialer_swarm_1_control
+            .open_stream(listening_swarm_peer_id, PROTOCOL_NAME)
+            .map(|r| r.unwrap()),
+        dialer_swarm_2_control
+            .open_stream(listening_swarm_peer_id, PROTOCOL_NAME)
+            .map(|r| r.unwrap()),
+    );
+    let _ = join!(
+        dialer_swarm_1_stream.write(b""),
+        dialer_swarm_2_stream.write(b""),
+    );
+
+    let mut dialer_swarm_1_dropped = false;
+    let mut dialer_swarm_2_dropped = false;
     loop {
         select! {
-            // We make sure that after 12 seconds one of the two connections is dropped (the swarm used in the tests uses a default timeout of 10s and we increased the keepalive timeout for the tested behaviour to 13s).
-            // We cannot prevent both connections from being upgraded, but we can test that one of the two is dropped once the listener realized it is above the maximum peering degree.
-            // We do not know which one beforehand because they are started in parallel.
             () = sleep(Duration::from_secs(12)) => {
                 break;
             }
-            _ = listening_swarm.select_next_some() => {}
             dialer_swarm_1_event = dialer_swarm_1.select_next_some() => {
-                match dialer_swarm_1_event {
-                    SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
-                        let mut dialer_control = dialer_1_control.clone();
-                        spawn(async move {let _ = dialer_control.open_stream(listening_swarm_peer_id, PROTOCOL_NAME).await.unwrap().write(b"").await.unwrap();});
-                    }
-                    SwarmEvent::ConnectionClosed { endpoint, peer_id, .. } => {
-                        assert!(!dialer_2_dropped);
-                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
-                        assert!(endpoint.is_dialer());
-                        dialer_1_dropped = true;
-                    }
-                    _ => {}
+                if let SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } = dialer_swarm_1_event {
+                    assert_eq!(peer_id, listening_swarm_peer_id);
+                    assert!(endpoint.is_dialer());
+                    assert!(!dialer_swarm_2_dropped);
+                    dialer_swarm_1_dropped = true;
                 }
             }
             dialer_swarm_2_event = dialer_swarm_2.select_next_some() => {
-                match dialer_swarm_2_event {
-                    SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
-                        let mut dialer_control = dialer_2_control.clone();
-                        spawn(async move {let _ = dialer_control.open_stream(listening_swarm_peer_id, PROTOCOL_NAME).await.unwrap().write(b"").await.unwrap();});
-                    }
-                    SwarmEvent::ConnectionClosed { endpoint, peer_id, .. } => {
-                        assert!(!dialer_1_dropped);
-                        assert_eq!(peer_id, *listening_swarm.local_peer_id());
-                        assert!(endpoint.is_dialer());
-                        dialer_2_dropped = true;
-                    }
-                    _ => {}
+                if let SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } = dialer_swarm_2_event {
+                    assert_eq!(peer_id, listening_swarm_peer_id);
+                    assert!(endpoint.is_dialer());
+                    assert!(!dialer_swarm_1_dropped);
+                    dialer_swarm_2_dropped = true;
                 }
             }
         }
     }
 
-    assert!(dialer_1_dropped ^ dialer_2_dropped);
+    assert!(dialer_swarm_1_dropped ^ dialer_swarm_2_dropped);
 }
 
 #[test(tokio::test)]
@@ -244,45 +211,19 @@ async fn outgoing_connection_to_edge_peer() {
             .build()
     });
     let mut edge_swarm = TestSwarm::new(|_| StreamBehaviour::new());
-    let edge_swarm_control = edge_swarm.behaviour_mut().new_control();
 
-    let (edge_swarm_address, _) = edge_swarm.listen().await;
-    core_swarm.dial(edge_swarm_address).unwrap();
+    edge_swarm.listen().with_memory_addr_external().await;
+    core_swarm.connect(&mut edge_swarm).await;
 
-    let mut core_swarm_ready = false;
-    let mut edge_swarm_ready = false;
-    loop {
-        // We don't know which swarm will get notified first, so we need to check the
-        // same condition in both cases.
-        select! {
-            edge_swarm_event = edge_swarm.select_next_some() => {
-                if let SwarmEvent::ConnectionEstablished { peer_id, .. } = edge_swarm_event {
-                    assert_eq!(peer_id, *core_swarm.local_peer_id());
-                    assert!(!edge_swarm_ready);
-                    if core_swarm_ready {
-                        let mut control = edge_swarm_control.clone();
-                        let stream_control_res = control.open_stream(*core_swarm.local_peer_id(), PROTOCOL_NAME).await;
-                        // Since we use a dummy handler for outgoing connections to edge nodes, the stream upgrade should fail.
-                        assert!(matches!(stream_control_res, Err(OpenStreamError::UnsupportedProtocol(_))));
-                        break;
-                    }
-                    edge_swarm_ready = true;
-                }
-            }
-            core_swarm_event = core_swarm.select_next_some() => {
-                if let SwarmEvent::ConnectionEstablished { peer_id, .. } = core_swarm_event {
-                    assert_eq!(peer_id, *edge_swarm.local_peer_id());
-                    assert!(!core_swarm_ready);
-                    if edge_swarm_ready {
-                        let mut control = edge_swarm_control.clone();
-                        let stream_control_res = control.open_stream(*core_swarm.local_peer_id(), PROTOCOL_NAME).await;
-                        // Since we use a dummy handler for outgoing connections to edge nodes, the stream upgrade should fail.
-                        assert!(matches!(stream_control_res, Err(OpenStreamError::UnsupportedProtocol(_))));
-                        break;
-                    }
-                    core_swarm_ready = true;
-                }
-            }
-        }
-    }
+    // We use a dummy connection handler for core->edge outgoing connections, so
+    // upgrading the substream should not be allowed.
+    let stream_control_res = edge_swarm
+        .behaviour_mut()
+        .new_control()
+        .open_stream(*core_swarm.local_peer_id(), PROTOCOL_NAME)
+        .await;
+    assert!(matches!(
+        stream_control_res,
+        Err(OpenStreamError::UnsupportedProtocol(_))
+    ));
 }

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
@@ -1,7 +1,7 @@
 use test_log::test;
 
 #[test(tokio::test)]
-async fn receive_message() {}
+async fn receive_valid_message() {}
 
 #[test(tokio::test)]
-async fn receive_malformed_essage() {}
+async fn receive_malformed_message() {}

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
@@ -1,7 +1,7 @@
 use futures::{select, StreamExt as _};
 use libp2p::PeerId;
 use libp2p_stream::Behaviour as StreamBehaviour;
-use libp2p_swarm_test::SwarmExt;
+use libp2p_swarm_test::SwarmExt as _;
 use nomos_blend_scheduling::serialize_encapsulated_message;
 use nomos_libp2p::SwarmEvent;
 use test_log::test;
@@ -10,7 +10,7 @@ use crate::{
     core::{
         tests::utils::{TestEncapsulatedMessage, TestSwarm},
         with_edge::behaviour::{
-            tests::utils::{BehaviourBuilder, StreamBehaviourExt},
+            tests::utils::{BehaviourBuilder, StreamBehaviourExt as _},
             Event,
         },
     },

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
@@ -24,7 +24,7 @@ use crate::{
 async fn receive_valid_message() {
     let mut core_swarm = TestSwarm::new(|_| {
         BehaviourBuilder::default()
-            .with_edge_peer_membership(PeerId::random())
+            .with_core_peer_membership(PeerId::random())
             .build()
     });
     let mut edge_swarm = TestSwarm::new(|_| StreamBehaviour::new());
@@ -55,7 +55,7 @@ async fn receive_valid_message() {
 async fn message_timeout() {
     let mut core_swarm = TestSwarm::new(|_| {
         BehaviourBuilder::default()
-            .with_edge_peer_membership(PeerId::random())
+            .with_core_peer_membership(PeerId::random())
             .with_timeout(Duration::from_secs(1))
             .build()
     });
@@ -87,7 +87,7 @@ async fn message_timeout() {
 async fn receive_malformed_message() {
     let mut core_swarm = TestSwarm::new(|_| {
         BehaviourBuilder::default()
-            .with_edge_peer_membership(PeerId::random())
+            .with_core_peer_membership(PeerId::random())
             .build()
     });
     let mut edge_swarm = TestSwarm::new(|_| StreamBehaviour::new());

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
@@ -1,0 +1,7 @@
+use test_log::test;
+
+#[test(tokio::test)]
+async fn receive_message() {}
+
+#[test(tokio::test)]
+async fn receive_malformed_essage() {}

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
@@ -1,7 +1,87 @@
+use futures::{select, StreamExt as _};
+use libp2p::PeerId;
+use libp2p_stream::Behaviour as StreamBehaviour;
+use libp2p_swarm_test::SwarmExt;
+use nomos_blend_scheduling::serialize_encapsulated_message;
+use nomos_libp2p::SwarmEvent;
 use test_log::test;
 
-#[test(tokio::test)]
-async fn receive_valid_message() {}
+use crate::{
+    core::{
+        tests::utils::{TestEncapsulatedMessage, TestSwarm},
+        with_edge::behaviour::{
+            tests::utils::{BehaviourBuilder, StreamBehaviourExt},
+            Event,
+        },
+    },
+    message::ValidateMessagePublicHeader as _,
+    send_msg,
+};
 
 #[test(tokio::test)]
-async fn receive_malformed_message() {}
+async fn receive_valid_message() {
+    let mut core_swarm = TestSwarm::new(|_| {
+        BehaviourBuilder::default()
+            .with_edge_peer_membership(PeerId::random())
+            .build()
+    });
+    let mut edge_swarm = TestSwarm::new(|_| StreamBehaviour::new());
+
+    core_swarm.listen().with_memory_addr_external().await;
+    let stream = edge_swarm
+        .connect_and_upgrade_to_blend(&mut core_swarm)
+        .await;
+    let message = TestEncapsulatedMessage::new(b"test");
+    send_msg(stream, serialize_encapsulated_message(&message))
+        .await
+        .unwrap();
+
+    loop {
+        select! {
+            _ = edge_swarm.select_next_some() => {}
+            core_swarm_event = core_swarm.select_next_some() => {
+                if let SwarmEvent::Behaviour(Event::Message(received_message)) = core_swarm_event {
+                    assert_eq!(received_message, message.clone().validate_public_header().unwrap());
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[test(tokio::test)]
+async fn receive_malformed_message() {
+    let mut core_swarm = TestSwarm::new(|_| {
+        BehaviourBuilder::default()
+            .with_edge_peer_membership(PeerId::random())
+            .build()
+    });
+    let mut edge_swarm = TestSwarm::new(|_| StreamBehaviour::new());
+
+    core_swarm.listen().with_memory_addr_external().await;
+    let stream = edge_swarm
+        .connect_and_upgrade_to_blend(&mut core_swarm)
+        .await;
+    let malformed_message = TestEncapsulatedMessage::new_with_invalid_signature(b"invalid_message");
+    send_msg(stream, serialize_encapsulated_message(&malformed_message))
+        .await
+        .unwrap();
+
+    loop {
+        select! {
+            _ = edge_swarm.select_next_some() => {}
+            core_swarm_event = core_swarm.select_next_some() => {
+                match core_swarm_event {
+                    SwarmEvent::Behaviour(Event::Message(_)) => {
+                        panic!("No `Message` event should be generated for an invalid message received.");
+                    }
+                    SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                        assert_eq!(peer_id, *edge_swarm.local_peer_id());
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/mod.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/mod.rs
@@ -1,0 +1,2 @@
+mod bootstrapping;
+mod message_handling;

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/mod.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/mod.rs
@@ -1,2 +1,3 @@
 mod bootstrapping;
 mod message_handling;
+mod utils;

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
@@ -12,14 +12,14 @@ use crate::{core::with_edge::behaviour::Behaviour, PROTOCOL_NAME};
 
 #[derive(Default)]
 pub struct BehaviourBuilder {
-    edge_peer_ids: Vec<PeerId>,
+    core_peer_ids: Vec<PeerId>,
     max_incoming_connections: Option<usize>,
     timeout: Option<Duration>,
 }
 
 impl BehaviourBuilder {
-    pub fn with_edge_peer_membership(mut self, edge_peer_id: PeerId) -> Self {
-        self.edge_peer_ids.push(edge_peer_id);
+    pub fn with_core_peer_membership(mut self, edge_peer_id: PeerId) -> Self {
+        self.core_peer_ids.push(edge_peer_id);
         self
     }
 
@@ -34,11 +34,11 @@ impl BehaviourBuilder {
     }
 
     pub fn build(self) -> Behaviour {
-        let current_membership = if self.edge_peer_ids.is_empty() {
+        let current_membership = if self.core_peer_ids.is_empty() {
             None
         } else {
             Some(Membership::new(
-                self.edge_peer_ids
+                self.core_peer_ids
                     .into_iter()
                     .map(|edge_peer_id| Node {
                         address: Multiaddr::empty(),

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
@@ -1,0 +1,37 @@
+use core::time::Duration;
+use std::collections::{HashSet, VecDeque};
+
+use libp2p::{Multiaddr, PeerId};
+use nomos_blend_message::crypto::Ed25519PrivateKey;
+use nomos_blend_scheduling::membership::{Membership, Node};
+
+use crate::core::with_edge::behaviour::Behaviour;
+
+impl Behaviour {
+    #[must_use]
+    pub fn with_no_membership() -> Self {
+        Self {
+            connection_timeout: Duration::from_secs(1),
+            current_membership: None,
+            events: VecDeque::new(),
+            max_incoming_connections: 100,
+            upgraded_edge_peers: HashSet::new(),
+            waker: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_edge_peer(edge_peer_id: PeerId) -> Self {
+        let mut self_instance = Self::with_no_membership();
+        self_instance.current_membership = Some(Membership::new(
+            &[Node {
+                address: Multiaddr::empty(),
+                id: edge_peer_id,
+                public_key: Ed25519PrivateKey::generate().public_key(),
+            }],
+            None,
+        ));
+
+        self_instance
+    }
+}

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
@@ -2,7 +2,6 @@ use core::time::Duration;
 use std::collections::{HashSet, VecDeque};
 
 use async_trait::async_trait;
-use futures::AsyncWriteExt as _;
 use libp2p::{Multiaddr, PeerId, Stream, Swarm};
 use libp2p_stream::Behaviour as StreamBehaviour;
 use libp2p_swarm_test::SwarmExt as _;
@@ -70,8 +69,8 @@ pub trait StreamBehaviourExt: libp2p_swarm_test::SwarmExt {
 #[async_trait]
 impl StreamBehaviourExt for Swarm<StreamBehaviour> {
     async fn connect_and_upgrade_to_blend(&mut self, other: &mut Swarm<Behaviour>) -> Stream {
-        // We connect and write an empty byte into the stream so the blend node does not
-        // close the connection with an EOF error.
+        // We connect and return the stream preventing it from being dropped so the
+        // blend node does not close the connection with an EOF error.
         self.connect(other).await;
         self.behaviour_mut()
             .new_control()

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
@@ -73,13 +73,10 @@ impl StreamBehaviourExt for Swarm<StreamBehaviour> {
         // We connect and write an empty byte into the stream so the blend node does not
         // close the connection with an EOF error.
         self.connect(other).await;
-        let mut stream = self
-            .behaviour_mut()
+        self.behaviour_mut()
             .new_control()
             .open_stream(*other.local_peer_id(), PROTOCOL_NAME)
             .await
-            .unwrap();
-        let _ = stream.write(b"").await.unwrap();
-        stream
+            .unwrap()
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Blend testing PR 2/3 and based on top of the core->core testing one from which it shares most of the test setup infrastructure: https://github.com/logos-co/nomos/pull/1542.

This PR introduces test cases for all the edge cases I could think of, and helped me find a bug that happens when a number of edge peers connect to a core node which would bring the total number of connected peers above the maximum threshold. In some cases, we would still receive and bubble up to the swarm the messages we receive from both of them, although some of the connections should have been rejected. So we have a fix now with a two-step phase: we first upgrade the connection, and then when we are ready to receive we check again, and since libp2p is not multithreaded, we are sure that at any given time we are able to block unwanted connections from sending us messages. So I would say the testing effort is paying back the effort.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2, spec: @madxor.

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
