### PR TITLE
feat(da-network): historic sampling behavior - wait for connection on dial

### DIFF
--- a/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
@@ -511,7 +511,7 @@ where
         local_addr: &Multiaddr,
         remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        self.connection_broadcast_sender.send(peer).unwrap();
+        let _ = self.connection_broadcast_sender.send(peer);
 
         self.stream_behaviour
             .handle_established_inbound_connection(connection_id, peer, local_addr, remote_addr)
@@ -526,7 +526,7 @@ where
         role_override: Endpoint,
         port_use: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        self.connection_broadcast_sender.send(peer).unwrap();
+        let _ = self.connection_broadcast_sender.send(peer);
 
         self.stream_behaviour
             .handle_established_outbound_connection(

--- a/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 
 const MAX_PEER_RETRIES: usize = 5;
-const CONNECTION_WAIT_TIMEOUT: u64 = 3;
+const CONNECTION_WAIT_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Error)]
 enum StreamSamplingError {
@@ -141,7 +141,7 @@ where
         match stream_result {
             Ok(stream) => Ok(SampleStream { stream, peer_id }),
             Err(OpenStreamError::Io(io_err)) if io_err.kind() == ErrorKind::ConnectionReset => {
-                let timer = sleep(Duration::from_secs(CONNECTION_WAIT_TIMEOUT));
+                let timer = sleep(CONNECTION_WAIT_TIMEOUT);
                 tokio::pin!(timer);
 
                 loop {

--- a/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
@@ -27,10 +27,7 @@ use rand::{rngs::ThreadRng, seq::IteratorRandom as _};
 use subnetworks_assignations::MembershipHandler;
 use thiserror::Error;
 use tokio::{
-    sync::{
-        broadcast::error::RecvError,
-        mpsc::{self, UnboundedSender},
-    },
+    sync::mpsc::{self, UnboundedSender},
     time::{sleep, Duration},
 };
 use tokio_stream::wrappers::{BroadcastStream, UnboundedReceiverStream};
@@ -263,7 +260,7 @@ where
         control: Control,
         mut blob_ids: HashSet<BlobId>,
         subnetwork_id: SubnetworkId,
-        mut connection_receiver: tokio::sync::broadcast::Receiver<PeerId>,
+        connection_receiver: tokio::sync::broadcast::Receiver<PeerId>,
     ) -> Result<Vec<DaLightShare>, HistoricSamplingError> {
         // Pre-select up to MAX_PEER_RETRIES peers from the subnetwork
         let candidate_peers = {
@@ -278,7 +275,9 @@ where
                 break;
             }
 
-            match Self::open_stream(peer_id, control.clone(), &mut connection_receiver).await {
+            match Self::open_stream(peer_id, control.clone(), connection_receiver.resubscribe())
+                .await
+            {
                 Ok(mut stream) => {
                     let blob_ids_to_try: Vec<BlobId> = blob_ids.iter().copied().collect();
 
@@ -293,7 +292,6 @@ where
                             Err(err) => {
                                 log::error!("Failed to handle share request: {err}");
                                 // todo: close the stream
-                                maybe.stream.close().await;
                                 continue 'peers_loop; // Try next peer with
                                                       // remaining blobs
                             }
@@ -319,7 +317,7 @@ where
         local_peer_id: &PeerId,
         blob_ids: &HashSet<BlobId>,
         control: &Control,
-        mut connection_receiver: tokio::sync::broadcast::Receiver<PeerId>,
+        connection_receiver: tokio::sync::broadcast::Receiver<PeerId>,
     ) -> Result<Vec<DaSharesCommitments>, HistoricSamplingError> {
         // Pre-select up to MAX_PEER_RETRIES peers from a random subnet
         let candidate_peers = {
@@ -352,7 +350,9 @@ where
                 break;
             }
 
-            match Self::open_stream(peer_id, control.clone(), &mut connection_receiver).await {
+            match Self::open_stream(peer_id, control.clone(), connection_receiver.resubscribe())
+                .await
+            {
                 Ok(mut stream) => {
                     let blob_ids_to_try: Vec<BlobId> = remaining_blob_ids.iter().copied().collect();
 

--- a/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 
 const MAX_PEER_RETRIES: usize = 5;
-const CONNECTION_WAIT_TIMEOUT: Duration = Duration::from_secs(3);
+const CONNECTION_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Error)]
 enum StreamSamplingError {

--- a/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
@@ -294,6 +294,7 @@ where
                             }
                             Err(err) => {
                                 log::error!("Failed to handle share request: {err}");
+                                // todo: close the stream
                                 continue 'peers_loop; // Try next peer with
                                                       // remaining blobs
                             }
@@ -365,6 +366,7 @@ where
                                 stream = new_stream;
                             }
                             Err(err) => {
+                                // todo: close the stream
                                 log::error!("Failed to get commitment from peer {peer_id}: {err}");
                                 continue 'peers_loop;
                             }

--- a/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/historic/request_behaviour.rs
@@ -147,7 +147,7 @@ where
 
                 tokio::select! {
                     Some(_) = connection_stream.next() => {
-                        // Connection established for our peer - retry once
+                        // Move on to retry
                     }
                     () = &mut timer => {
                         return Err(StreamSamplingError::Timeout);


### PR DESCRIPTION
## 1. What does this PR implement?

Idea for solving the open stream returning connection reset error on dial. Context:https://github.com/logos-co/nomos/pull/1545#discussion_r2283152905
