### PR TITLE
chore(blend): make Blend protocol name a parameter

### DIFF
--- a/nodes/nomos-executor/config.yaml
+++ b/nodes/nomos-executor/config.yaml
@@ -25,6 +25,7 @@ blend:
       start: 4
       end: 8
     max_dial_attempts_per_peer: 3
+    protocol_name: /nomos/blend/1.0.0
   crypto:
     signing_private_key: 32e4b52b78e0e8273f31e2ae0826d09b0348d4c66824af4f51ec4ef338082211
     num_blend_layers: 1

--- a/nodes/nomos-node/config.yaml
+++ b/nodes/nomos-node/config.yaml
@@ -25,6 +25,7 @@ blend:
       start: 4
       end: 8
     max_dial_attempts_per_peer: 3      
+    protocol_name: /nomos/blend/1.0.0
   crypto:
     signing_private_key: 32e4b52b78e0e8273f31e2ae0826d09b0348d4c66824af4f51ec4ef338082211
     num_blend_layers: 1

--- a/nomos-blend/network/src/core/mod.rs
+++ b/nomos-blend/network/src/core/mod.rs
@@ -4,7 +4,7 @@ pub mod with_edge;
 #[cfg(test)]
 mod tests;
 
-use libp2p::PeerId;
+use libp2p::{PeerId, StreamProtocol};
 use nomos_blend_scheduling::membership::Membership;
 
 use self::{
@@ -55,6 +55,7 @@ impl<ObservationWindowClockProvider> NetworkBehaviour<ObservationWindowClockProv
         observation_window_clock_provider: ObservationWindowClockProvider,
         current_membership: Option<Membership<PeerId>>,
         local_peer_id: PeerId,
+        protocol_name: StreamProtocol,
     ) -> Self {
         Self {
             with_core: CoreToCoreBehaviour::new(
@@ -62,8 +63,13 @@ impl<ObservationWindowClockProvider> NetworkBehaviour<ObservationWindowClockProv
                 observation_window_clock_provider,
                 current_membership.clone(),
                 local_peer_id,
+                protocol_name.clone(),
             ),
-            with_edge: CoreToEdgeBehaviour::new(&config.with_edge, current_membership),
+            with_edge: CoreToEdgeBehaviour::new(
+                &config.with_edge,
+                current_membership,
+                protocol_name,
+            ),
         }
     }
 }

--- a/nomos-blend/network/src/core/tests/utils.rs
+++ b/nomos-blend/network/src/core/tests/utils.rs
@@ -6,7 +6,7 @@ use core::{
 
 use libp2p::{
     identity::{ed25519::PublicKey, Keypair},
-    PeerId, Swarm,
+    PeerId, StreamProtocol, Swarm,
 };
 use libp2p_swarm_test::SwarmExt as _;
 use nomos_blend_message::{
@@ -19,6 +19,8 @@ use nomos_blend_message::{
 };
 use nomos_blend_scheduling::EncapsulatedMessage;
 use nomos_libp2p::NetworkBehaviour;
+
+pub const PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/blend/core-behaviour/test");
 
 pub struct TestSwarm<Behaviour>(Swarm<Behaviour>)
 where

--- a/nomos-blend/network/src/core/with_core/behaviour/handler/mod.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/handler/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     core::with_core::behaviour::handler::conn_maintenance::{
         ConnectionMonitor, ConnectionMonitorOutput,
     },
-    recv_msg, send_msg, PROTOCOL_NAME,
+    recv_msg, send_msg,
 };
 
 pub(super) mod conn_maintenance;
@@ -42,6 +42,7 @@ pub struct ConnectionHandler<ConnectionWindowClock> {
     outbound_msgs: VecDeque<Vec<u8>>,
     pending_events_to_behaviour: VecDeque<ToBehaviour>,
     monitor: ConnectionMonitor<ConnectionWindowClock>,
+    protocol_name: StreamProtocol,
     waker: Option<Waker>,
 }
 
@@ -67,7 +68,10 @@ enum OutboundSubstreamState {
 }
 
 impl<ConnectionWindowClock> ConnectionHandler<ConnectionWindowClock> {
-    pub fn new(monitor: ConnectionMonitor<ConnectionWindowClock>) -> Self {
+    pub fn new(
+        monitor: ConnectionMonitor<ConnectionWindowClock>,
+        protocol_name: StreamProtocol,
+    ) -> Self {
         tracing::trace!(target: LOG_TARGET, "Initializing core->core connection handler.");
         Self {
             inbound_substream: None,
@@ -75,6 +79,7 @@ impl<ConnectionWindowClock> ConnectionHandler<ConnectionWindowClock> {
             outbound_msgs: VecDeque::new(),
             pending_events_to_behaviour: VecDeque::new(),
             monitor,
+            protocol_name,
             waker: None,
         }
     }
@@ -150,7 +155,7 @@ where
 
     #[expect(deprecated, reason = "Self::InboundOpenInfo is deprecated")]
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
-        SubstreamProtocol::new(ReadyUpgrade::new(PROTOCOL_NAME), ())
+        SubstreamProtocol::new(ReadyUpgrade::new(self.protocol_name.clone()), ())
     }
 
     #[expect(deprecated, reason = "Self::OutboundOpenInfo is deprecated")]
@@ -300,7 +305,10 @@ where
                     tracing::debug!(target: LOG_TARGET, "Outbound substream is not initialized yet. Requesting the swarm to open one.");
                     self.outbound_substream = Some(OutboundSubstreamState::PendingOpenSubstream);
                     return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                        protocol: SubstreamProtocol::new(ReadyUpgrade::new(PROTOCOL_NAME), ()),
+                        protocol: SubstreamProtocol::new(
+                            ReadyUpgrade::new(self.protocol_name.clone()),
+                            (),
+                        ),
                     });
                 }
             }

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/utils.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/utils.rs
@@ -9,7 +9,10 @@ use nomos_libp2p::{NetworkBehaviour, SwarmEvent};
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 
-use crate::core::with_core::behaviour::{Behaviour, Event, IntervalStreamProvider};
+use crate::core::{
+    tests::utils::PROTOCOL_NAME,
+    with_core::behaviour::{Behaviour, Event, IntervalStreamProvider},
+};
 
 #[derive(Clone)]
 pub struct IntervalProvider(Duration, RangeInclusive<u64>);
@@ -96,6 +99,7 @@ impl BehaviourBuilder {
             current_membership: None,
             peering_degree: self.peering_degree.unwrap_or(1..=1),
             local_peer_id,
+            protocol_name: PROTOCOL_NAME,
         }
     }
 }

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/bootstrapping.rs
@@ -9,12 +9,9 @@ use nomos_libp2p::SwarmEvent;
 use test_log::test;
 use tokio::{select, spawn, time::sleep};
 
-use crate::{
-    core::{
-        tests::utils::TestSwarm,
-        with_edge::behaviour::tests::utils::{BehaviourBuilder, StreamBehaviourExt as _},
-    },
-    PROTOCOL_NAME,
+use crate::core::{
+    tests::utils::{TestSwarm, PROTOCOL_NAME},
+    with_edge::behaviour::tests::utils::{BehaviourBuilder, StreamBehaviourExt as _},
 };
 
 #[test(tokio::test)]

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
@@ -8,7 +8,7 @@ use libp2p_swarm_test::SwarmExt as _;
 use nomos_blend_message::crypto::Ed25519PrivateKey;
 use nomos_blend_scheduling::membership::{Membership, Node};
 
-use crate::{core::with_edge::behaviour::Behaviour, PROTOCOL_NAME};
+use crate::core::{tests::utils::PROTOCOL_NAME, with_edge::behaviour::Behaviour};
 
 #[derive(Default)]
 pub struct BehaviourBuilder {
@@ -57,6 +57,7 @@ impl BehaviourBuilder {
             connection_timeout: self.timeout.unwrap_or(Duration::from_secs(1)),
             upgraded_edge_peers: HashSet::new(),
             max_incoming_connections: self.max_incoming_connections.unwrap_or(100),
+            protocol_name: PROTOCOL_NAME,
         }
     }
 }

--- a/nomos-libp2p/src/protocol_name.rs
+++ b/nomos-libp2p/src/protocol_name.rs
@@ -1,4 +1,7 @@
-use serde::{Deserialize, Serialize};
+use core::ops::{Deref, DerefMut};
+
+use libp2p::StreamProtocol as Libp2pStreamProtocol;
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 pub const MAINNET_KAD_PROTOCOL_NAME: &str = "/nomos/kad/1.0.0";
 pub const MAINNET_IDENTIFY_PROTOCOL_NAME: &str = "/nomos/identify/1.0.0";
@@ -42,5 +45,73 @@ impl ProtocolName {
             Self::Unittest => UNITTEST_IDENTIFY_PROTOCOL_NAME,
             Self::Integration => INTEGRATION_IDENTIFY_PROTOCOL_NAME,
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Struct wrapping around a `StreamProtocol` to make it serializable and
+/// catch any invalid protocol names already at config reading instead of later
+/// on.
+pub struct StreamProtocol(
+    #[serde(
+        serialize_with = "serialize_stream_protocol",
+        deserialize_with = "deserialize_stream_protocol"
+    )]
+    Libp2pStreamProtocol,
+);
+
+fn serialize_stream_protocol<S>(
+    protocol_name: &Libp2pStreamProtocol,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    protocol_name.as_ref().serialize(serializer)
+}
+
+fn deserialize_stream_protocol<'de, D>(deserializer: D) -> Result<Libp2pStreamProtocol, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let protocol_name = String::deserialize(deserializer)?;
+    Libp2pStreamProtocol::try_from_owned(protocol_name).map_err(Error::custom)
+}
+
+impl StreamProtocol {
+    #[must_use]
+    pub const fn new(protocol_name: &'static str) -> Self {
+        Self(Libp2pStreamProtocol::new(protocol_name))
+    }
+
+    #[must_use]
+    pub fn into_inner(self) -> Libp2pStreamProtocol {
+        self.0
+    }
+}
+
+impl Deref for StreamProtocol {
+    type Target = Libp2pStreamProtocol;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for StreamProtocol {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<StreamProtocol> for Libp2pStreamProtocol {
+    fn from(value: StreamProtocol) -> Self {
+        value.0
+    }
+}
+
+impl From<Libp2pStreamProtocol> for StreamProtocol {
+    fn from(value: Libp2pStreamProtocol) -> Self {
+        Self(value)
     }
 }

--- a/nomos-services/blend/src/core/backends/libp2p/behaviour.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/behaviour.rs
@@ -51,6 +51,7 @@ impl BlendBehaviour {
                 observation_window_interval_provider,
                 Some(config.membership()),
                 config.backend.peer_id(),
+                config.backend.protocol_name.clone().into_inner(),
             ),
             limits: libp2p::connection_limits::Behaviour::new(
                 ConnectionLimits::default()

--- a/nomos-services/blend/src/core/backends/libp2p/settings.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/settings.rs
@@ -2,7 +2,7 @@ use core::time::Duration;
 use std::{num::NonZeroU64, ops::RangeInclusive};
 
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
-use nomos_libp2p::ed25519;
+use nomos_libp2p::{ed25519, protocol_name::StreamProtocol};
 use nomos_utils::math::NonNegativeF64;
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +25,7 @@ pub struct Libp2pBlendBackendSettings {
     pub edge_node_connection_timeout: Duration,
     pub max_edge_node_incoming_connections: u64,
     pub max_dial_attempts_per_peer: NonZeroU64,
+    pub protocol_name: StreamProtocol,
 }
 
 impl Libp2pBlendBackendSettings {

--- a/tests/src/topology/configs/blend.rs
+++ b/tests/src/topology/configs/blend.rs
@@ -7,6 +7,7 @@ use nomos_blend_service::core::backends::libp2p::Libp2pBlendBackendSettings;
 use nomos_libp2p::{
     ed25519::{self, Keypair as Ed25519Keypair},
     identity::Keypair,
+    protocol_name::StreamProtocol,
     Multiaddr, PeerId,
 };
 
@@ -46,6 +47,7 @@ pub fn create_blend_configs(ids: &[[u8; 32]]) -> Vec<GeneralBlendConfig> {
                     max_edge_node_incoming_connections: 300,
                     max_dial_attempts_per_peer: NonZeroU64::try_from(3)
                         .expect("Max dial attempts per peer cannot be zero."),
+                    protocol_name: StreamProtocol::new("/blend/integration-tests"),
                 },
                 private_key: Ed25519PrivateKey::generate(),
                 membership: Vec::new(),


### PR DESCRIPTION
It makes the Blend libp2p stack configurable in terms of what protocol name it speaks, but it adds the config to the existing config to make the codebase compile. We want to revise how we set-up a top-level "operation mode" to distinguish among the different deployments.