### PR TITLE
fix(da): Remove rwlock from mempool publish trigger

### DIFF
--- a/nomos-services/data-availability/verifier/src/backend/trigger.rs
+++ b/nomos-services/data-availability/verifier/src/backend/trigger.rs
@@ -1,10 +1,6 @@
 use std::{
     collections::HashMap,
     hash::Hash,
-    sync::{
-        atomic::{AtomicBool, AtomicU16, Ordering},
-        Arc, RwLock,
-    },
     time::{Duration, Instant},
 };
 
@@ -42,15 +38,15 @@ pub enum ShareState {
 
 #[derive(Debug)]
 struct ShareEntry {
-    count: AtomicU16,
+    count: u16,
     created_at: Instant,
     assignations: u16,
-    expired: AtomicBool,
+    expired: bool,
 }
 
 pub struct MempoolPublishTrigger<Id> {
     config: MempoolPublishTriggerConfig,
-    received: Arc<RwLock<HashMap<Id, Arc<ShareEntry>>>>,
+    received: HashMap<Id, ShareEntry>,
 }
 
 impl<Id: Clone + Hash + Eq> MempoolPublishTrigger<Id> {
@@ -58,32 +54,25 @@ impl<Id: Clone + Hash + Eq> MempoolPublishTrigger<Id> {
     pub fn new(config: MempoolPublishTriggerConfig) -> Self {
         Self {
             config,
-            received: Arc::new(RwLock::new(HashMap::new())),
+            received: HashMap::new(),
         }
     }
 
-    pub fn update(&self, blob_id: Id, assignations: u16) -> ShareState {
-        let maybe_entry = self.received.read().unwrap().get(&blob_id).cloned();
-
-        let entry = maybe_entry.unwrap_or_else(|| {
-            let mut map = self.received.write().unwrap();
-            Arc::clone(map.entry(blob_id).or_insert_with(|| {
-                Arc::new(ShareEntry {
-                    count: AtomicU16::new(0),
-                    created_at: Instant::now(),
-                    assignations,
-                    expired: AtomicBool::new(false),
-                })
-            }))
+    pub fn update(&mut self, blob_id: Id, assignations: u16) -> ShareState {
+        let entry = self.received.entry(blob_id).or_insert_with(|| ShareEntry {
+            count: 0,
+            created_at: Instant::now(),
+            assignations,
+            expired: false,
         });
 
-        if entry.expired.load(Ordering::Acquire) {
+        if entry.expired {
             return ShareState::Expired;
         }
 
-        let new_count = entry.count.fetch_add(1, Ordering::AcqRel) + 1;
+        entry.count += 1;
 
-        if new_count >= entry.assignations {
+        if entry.count >= entry.assignations {
             ShareState::Complete
         } else {
             ShareState::Incomplete
@@ -91,22 +80,20 @@ impl<Id: Clone + Hash + Eq> MempoolPublishTrigger<Id> {
     }
 
     #[must_use]
-    pub fn prune(&self, now: Instant) -> Vec<Id> {
+    pub fn prune(&mut self, now: Instant) -> Vec<Id> {
         let mut to_publish = Vec::new();
 
-        let mut map = self.received.write().unwrap();
-
-        map.retain(|blob_id, state| {
+        self.received.retain(|blob_id, state| {
             let elapsed = now.duration_since(state.created_at);
 
             if elapsed >= self.config.prune_duration {
                 return false;
             }
 
-            if !state.expired.load(Ordering::Acquire) && elapsed >= self.config.share_duration {
-                state.expired.store(true, Ordering::Release);
+            if !state.expired && elapsed >= self.config.share_duration {
+                state.expired = true;
 
-                let count = state.count.load(Ordering::Acquire);
+                let count = state.count;
                 let threshold = (f64::from(state.assignations)
                     * self.config.publish_threshold.get())
                 .ceil() as u16;
@@ -125,23 +112,17 @@ impl<Id: Clone + Hash + Eq> MempoolPublishTrigger<Id> {
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
-
     use super::*;
 
     const BLOB_ID: [u8; 32] = [1; 32];
 
     impl<Id: Hash + Eq> MempoolPublishTrigger<Id> {
         fn len(&self) -> usize {
-            self.received.read().unwrap().len()
+            self.received.len()
         }
 
         fn get_count(&self, blob_id: &Id) -> Option<u16> {
-            self.received
-                .read()
-                .unwrap()
-                .get(blob_id)
-                .map(|e| e.count.load(Ordering::Relaxed))
+            self.received.get(blob_id).map(|e| e.count)
         }
     }
 
@@ -156,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_update_reaches_complete() {
-        let trigger = MempoolPublishTrigger::new(test_config());
+        let mut trigger = MempoolPublishTrigger::new(test_config());
         let assignations = 3;
 
         assert_eq!(
@@ -181,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_prune_and_publish() {
-        let trigger = MempoolPublishTrigger::new(test_config());
+        let mut trigger = MempoolPublishTrigger::new(test_config());
         let now = Instant::now();
 
         // 6 out of 10 shares received (60%).
@@ -198,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_prune_and_not_publish() {
-        let trigger = MempoolPublishTrigger::new(test_config());
+        let mut trigger = MempoolPublishTrigger::new(test_config());
         let now = Instant::now();
 
         // 4 out of 10 shares received (40%), which is < 50% threshold.
@@ -215,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_prune_removes_old_entry() {
-        let trigger = MempoolPublishTrigger::new(test_config());
+        let mut trigger = MempoolPublishTrigger::new(test_config());
         let now = Instant::now();
 
         trigger.update(BLOB_ID, 10);
@@ -231,7 +212,7 @@ mod tests {
     #[test]
     fn test_update_on_expired_entry() {
         let now = Instant::now();
-        let trigger = MempoolPublishTrigger::new(test_config());
+        let mut trigger = MempoolPublishTrigger::new(test_config());
         trigger.update(BLOB_ID, 10);
 
         let later = now.checked_add(Duration::from_secs(6)).unwrap();
@@ -243,7 +224,7 @@ mod tests {
     #[test]
     fn test_prune_publish_is_once() {
         let now = Instant::now();
-        let trigger = MempoolPublishTrigger::new(test_config());
+        let mut trigger = MempoolPublishTrigger::new(test_config());
         for _ in 0..5 {
             trigger.update(BLOB_ID, 10);
         }
@@ -251,44 +232,5 @@ mod tests {
         let later = now.checked_add(Duration::from_secs(6)).unwrap();
         assert_eq!(trigger.prune(later), vec![BLOB_ID]);
         assert!(trigger.prune(later).is_empty());
-    }
-
-    #[test]
-    fn test_concurrent_updates() {
-        let assignations = 100;
-        let trigger = Arc::new(MempoolPublishTrigger::new(test_config()));
-
-        let mut handles = vec![];
-        for _ in 0..assignations {
-            let trigger_clone = Arc::clone(&trigger);
-            handles.push(thread::spawn(move || {
-                trigger_clone.update(BLOB_ID, assignations as u16)
-            }));
-        }
-
-        let mut complete_count = 0;
-        let mut incomplete_count = 0;
-        for handle in handles {
-            match handle.join().unwrap() {
-                ShareState::Complete => complete_count += 1,
-                ShareState::Incomplete => incomplete_count += 1,
-                ShareState::Expired => panic!("Should not be expired"),
-            }
-        }
-
-        assert_eq!(
-            complete_count, 1,
-            "Exactly one update should return Complete"
-        );
-        assert_eq!(
-            incomplete_count,
-            assignations - 1,
-            "The rest should be Incomplete"
-        );
-        assert_eq!(
-            trigger.get_count(&BLOB_ID),
-            Some(assignations as u16),
-            "Final count should match number of updates"
-        );
     }
 }

--- a/nomos-services/data-availability/verifier/src/lib.rs
+++ b/nomos-services/data-availability/verifier/src/lib.rs
@@ -141,7 +141,7 @@ where
     async fn handle_new_share(
         verifier: &ShareVerifier,
         storage_adapter: &Storage,
-        mempool_trigger: &MempoolPublishTrigger<<ShareVerifier::DaShare as Share>::BlobId>,
+        mempool_trigger: &mut MempoolPublishTrigger<<ShareVerifier::DaShare as Share>::BlobId>,
         mempool_adapter: &MempoolAdapter,
         share: ShareVerifier::DaShare,
     ) -> Result<(), DynError> {
@@ -194,7 +194,7 @@ where
 
     async fn prune_pending_txs(
         storage_adapter: &Storage,
-        mempool_trigger: &MempoolPublishTrigger<<ShareVerifier::DaShare as Share>::BlobId>,
+        mempool_trigger: &mut MempoolPublishTrigger<<ShareVerifier::DaShare as Share>::BlobId>,
         mempool_adapter: &MempoolAdapter,
     ) -> Result<(), DynError> {
         let now = Instant::now();
@@ -385,7 +385,7 @@ where
         );
 
         let mut prune_interval = tokio::time::interval(mempool_trigger_settings.prune_interval);
-        let mempool_trigger = MempoolPublishTrigger::new(mempool_trigger_settings);
+        let mut mempool_trigger = MempoolPublishTrigger::new(mempool_trigger_settings);
 
         wait_until_services_are_ready!(
             &service_resources_handle.overwatch_handle,
@@ -402,7 +402,7 @@ where
                     if let Err(err) =  Self::handle_new_share(
                         &share_verifier,
                         &storage_adapter,
-                        &mempool_trigger,
+                        &mut mempool_trigger,
                         &mempool_adapter,
                         share
                     ).await {
@@ -435,7 +435,7 @@ where
                             match Self::handle_new_share(
                                 &share_verifier,
                                 &storage_adapter,
-                                &mempool_trigger,
+                                &mut mempool_trigger,
                                 &mempool_adapter,
                                 share
                             ).await {
@@ -472,7 +472,7 @@ where
                 _ = prune_interval.tick() => {
                     if let Err(err) = Self::prune_pending_txs(
                         &storage_adapter,
-                        &mempool_trigger,
+                        &mut mempool_trigger,
                         &mempool_adapter
                     ).await {
                         error!("Error pruning txs due to {err:?}");


### PR DESCRIPTION
## 1. What does this PR implement?

Overwatch service loop is executed in on one thread, no need to lock the list of blob ids for publishing as we can get the exclusive access to it.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@bacv

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
