### PR TITLE
feat(membership): introduce session forming in mock backend membershi…

### DIFF
--- a/nomos-core/chain-defs/src/block/mod.rs
+++ b/nomos-core/chain-defs/src/block/mod.rs
@@ -9,6 +9,8 @@ pub type TxHash = [u8; 32];
 
 pub type BlockNumber = u64;
 
+pub type SessionNumber = u64;
+
 /// A block
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Block<Tx: Clone + Eq, BlobCertificate: Clone + Eq> {

--- a/nomos-services/membership/src/backends/mock.rs
+++ b/nomos-services/membership/src/backends/mock.rs
@@ -1,32 +1,40 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
-    vec,
+    str,
 };
 
 use nomos_core::{
-    block::BlockNumber,
+    block::{BlockNumber, SessionNumber},
     sdp::{FinalizedBlockEvent, FinalizedBlockEventUpdate, Locator, ProviderId, ServiceType},
 };
 use serde::{Deserialize, Serialize};
 
-use super::{MembershipBackend, MembershipBackendError, MembershipBackendServiceSettings};
-use crate::MembershipProviders;
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MockMembershipBackendSettings {
-    pub settings_per_service: HashMap<ServiceType, MembershipBackendServiceSettings>,
-    pub initial_membership: HashMap<BlockNumber, MockMembershipEntry>,
-    pub initial_locators_mapping: HashMap<ProviderId, BTreeSet<Locator>>,
-    pub latest_block_number: BlockNumber,
-}
+use super::{MembershipBackend, MembershipBackendError};
+use crate::{backends::NewSesssion, MembershipProviders};
 
 type MockMembershipEntry = HashMap<ServiceType, HashSet<ProviderId>>;
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MockMembershipBackendSettings {
+    pub session_size_blocks: u32,
+    pub session_zero_membership: MockMembershipEntry,
+    pub session_zero_locators_mapping: HashMap<ProviderId, BTreeSet<Locator>>,
+}
+
 pub struct MockMembershipBackend {
-    settings: HashMap<ServiceType, MembershipBackendServiceSettings>,
-    membership: HashMap<BlockNumber, MockMembershipEntry>,
-    locators_mapping: HashMap<ProviderId, BTreeSet<Locator>>,
+    // Only store the latest completed session
+    active_session_id: SessionNumber,
+    active_session_membership: MockMembershipEntry,
+    active_session_locators: HashMap<ProviderId, BTreeSet<Locator>>,
+
+    // Current session state
     latest_block_number: BlockNumber,
+    session_size: u32,
+
+    // In-flight session being formed
+    forming_session_id: SessionNumber,
+    forming_session_updates: MockMembershipEntry,
+    forming_session_locators: HashMap<ProviderId, BTreeSet<Locator>>,
 }
 
 #[async_trait::async_trait]
@@ -34,52 +42,43 @@ impl MembershipBackend for MockMembershipBackend {
     type Settings = MockMembershipBackendSettings;
     fn init(settings: MockMembershipBackendSettings) -> Self {
         Self {
-            membership: settings.initial_membership.clone(),
-            latest_block_number: settings.latest_block_number,
-            settings: settings.settings_per_service,
-            locators_mapping: settings.initial_locators_mapping,
+            active_session_id: 0,
+            active_session_membership: settings.session_zero_membership.clone(),
+            active_session_locators: settings.session_zero_locators_mapping.clone(),
+            latest_block_number: 0,
+            session_size: settings.session_size_blocks,
+            // Start forming session 1 immediately as session 0 is seeded
+            forming_session_id: 1,
+            forming_session_updates: settings.session_zero_membership,
+            forming_session_locators: settings.session_zero_locators_mapping,
         }
-    }
-
-    async fn get_providers_at(
-        &self,
-        service_type: ServiceType,
-        block_number: BlockNumber,
-    ) -> Result<MembershipProviders, MembershipBackendError> {
-        // todo: figure out blocks skipped by update if neccessary
-        let k = self
-            .settings
-            .get(&service_type)
-            .ok_or_else(|| MembershipBackendError::Other("Service type not found".into()))?;
-        let index = block_number.saturating_sub(k.historical_block_delta);
-        return Ok(self.get_snapshot(index, service_type));
     }
 
     async fn get_latest_providers(
         &self,
         service_type: ServiceType,
     ) -> Result<MembershipProviders, MembershipBackendError> {
-        return Ok(self.get_snapshot(self.latest_block_number, service_type));
+        Ok(self.get_active_session_snapshot(service_type))
     }
 
     async fn update(
         &mut self,
         update: FinalizedBlockEvent,
-    ) -> Result<HashMap<ServiceType, MembershipProviders>, MembershipBackendError> {
+    ) -> Result<NewSesssion, MembershipBackendError> {
         let block_number = update.block_number;
+
+        tracing::debug!(
+            "Uupdating membership: {:?}, block {}, latest_block_number: {}",
+            update,
+            block_number,
+            self.latest_block_number
+        );
 
         if block_number <= self.latest_block_number {
             return Err(MembershipBackendError::BlockFromPast);
         }
 
-        let mut latest_entry = self
-            .membership
-            .get(&self.latest_block_number)
-            .cloned()
-            .unwrap_or_default();
-
-        let mut updated_service_types = vec![];
-
+        // Apply updates to forming session
         for FinalizedBlockEventUpdate {
             service_type,
             provider_id,
@@ -87,59 +86,76 @@ impl MembershipBackend for MockMembershipBackend {
             locators,
         } in update.updates
         {
-            if !self.settings.contains_key(&service_type) {
-                continue;
-            }
-
-            updated_service_types.push(service_type);
-
-            let service_data = latest_entry.entry(service_type).or_default();
+            let service_data = self
+                .forming_session_updates
+                .entry(service_type)
+                .or_default();
 
             match state {
                 nomos_core::sdp::DeclarationState::Active => {
-                    self.locators_mapping.insert(provider_id, locators.clone());
+                    self.forming_session_locators.insert(provider_id, locators);
                     service_data.insert(provider_id);
                 }
                 nomos_core::sdp::DeclarationState::Inactive
                 | nomos_core::sdp::DeclarationState::Withdrawn => {
                     service_data.remove(&provider_id);
-                    self.locators_mapping.remove(&provider_id);
+                    self.forming_session_locators.remove(&provider_id);
                 }
             }
         }
 
         self.latest_block_number = block_number;
-        self.membership.insert(block_number, latest_entry.clone());
 
-        let result = updated_service_types
-            .into_iter()
-            .map(|service_type| {
-                let snapshot = self.get_snapshot(block_number, service_type);
-                (service_type, snapshot)
-            })
-            .collect();
+        let next_session_id = self.block_to_session(block_number + 1);
 
-        Ok(result)
+        // Check if forming session is complete
+        if self.forming_session_id <= next_session_id {
+            // Move forming session to active
+            self.active_session_id = self.forming_session_id;
+            self.active_session_membership = self.forming_session_updates.clone();
+            self.active_session_locators = self.forming_session_locators.clone();
+
+            // Prepare result
+            let result = self
+                .active_session_membership
+                .keys()
+                .map(|service_type| {
+                    (
+                        *service_type,
+                        self.get_active_session_snapshot(*service_type),
+                    )
+                })
+                .collect();
+
+            // Start next session
+            self.forming_session_id += 1;
+            self.forming_session_updates = self.active_session_membership.clone();
+            self.forming_session_locators = self.active_session_locators.clone();
+
+            Ok(Some(result))
+        } else {
+            // Session still forming
+            Ok(None)
+        }
     }
 }
 
 impl MockMembershipBackend {
-    fn get_snapshot(
-        &self,
-        block_number: BlockNumber,
-        service_type: ServiceType,
-    ) -> MembershipProviders {
+    const fn block_to_session(&self, block_number: BlockNumber) -> SessionNumber {
+        block_number / (self.session_size as BlockNumber)
+    }
+
+    fn get_active_session_snapshot(&self, service_type: ServiceType) -> MembershipProviders {
         let snapshot = self
-            .membership
-            .get(&block_number)
-            .and_then(|entry| entry.get(&service_type))
-            .map(|snapshot| {
-                snapshot
+            .active_session_membership
+            .get(&service_type)
+            .map(|providers| {
+                providers
                     .iter()
                     .map(|provider_id| {
                         (
                             *provider_id,
-                            self.locators_mapping
+                            self.active_session_locators
                                 .get(provider_id)
                                 .cloned()
                                 .unwrap_or_default(),
@@ -149,7 +165,7 @@ impl MockMembershipBackend {
             })
             .unwrap_or_default();
 
-        (block_number, snapshot)
+        (self.active_session_id, snapshot)
     }
 }
 
@@ -158,412 +174,231 @@ mod tests {
     use std::collections::{BTreeSet, HashMap, HashSet};
 
     use multiaddr::multiaddr;
-    use nomos_core::{
-        block::BlockNumber,
-        sdp::{
-            DeclarationId, DeclarationInfo, DeclarationMessage, DeclarationState,
-            FinalizedBlockEvent, FinalizedBlockEventUpdate, Locator, ProviderId, ServiceType,
-            ZkPublicKey,
-        },
+    use nomos_core::sdp::{
+        DeclarationState, FinalizedBlockEvent, FinalizedBlockEventUpdate, Locator, ProviderId,
+        ServiceType,
     };
 
-    use super::{
-        MembershipBackend as _, MembershipBackendServiceSettings, MockMembershipBackend,
-        MockMembershipBackendSettings,
-    };
-    use crate::MembershipProviders;
+    use super::{MembershipBackend as _, MockMembershipBackend, MockMembershipBackendSettings};
+    use crate::backends::MembershipBackendError;
 
-    // Helper function to create ProviderId with specified bytes
-    fn create_provider_id(seed: u8) -> ProviderId {
-        let mut bytes = [0u8; 32];
-        bytes[0] = seed;
-        ProviderId(bytes)
+    fn pid(seed: u8) -> ProviderId {
+        let mut b = [0u8; 32];
+        b[0] = seed;
+        ProviderId(b)
     }
 
-    // Helper function to create DeclarationId with specified bytes
-    fn create_declaration_id(seed: u8) -> DeclarationId {
-        let mut bytes = [0u8; 32];
-        bytes[0] = seed;
-        DeclarationId(bytes)
-    }
-
-    // Helper function to create ProviderInfo
-    fn create_provider_info(seed: u8, block_number: BlockNumber) -> DeclarationInfo {
-        DeclarationInfo::new(
-            block_number,
-            DeclarationMessage {
-                service_type: ServiceType::DataAvailability,
-                locators: Vec::new(),
-                provider_id: create_provider_id(seed),
-                zk_id: ZkPublicKey([0; 32]),
-            },
-        )
-    }
-
-    fn create_locator(seed: u8) -> Locator {
+    fn locator(seed: u8) -> Locator {
         Locator::new(multiaddr!(
             Ip4([10, 0, 0, seed]),
             Udp(8000u16 + u16::from(seed))
         ))
     }
 
-    // Helper function to create DeclarationUpdate
-    fn create_declaration_update(
-        seed: u8,
-        service_type: ServiceType,
-        num_locators: usize,
-    ) -> DeclarationInfo {
-        let locators = (0..num_locators)
-            .map(|i| create_locator(seed + i as u8))
-            .collect();
-        let zk_id = ZkPublicKey([0; 32]);
-
-        DeclarationInfo {
-            id: create_declaration_id(seed),
-            provider_id: create_provider_id(seed),
-            service: service_type,
-            locators,
-            zk_id,
-            created: 0,
-            active: Some(1),
-            withdrawn: None,
-        }
+    fn locs<const N: usize>(base: u8) -> BTreeSet<Locator> {
+        (0..N).map(|i| locator(base + i as u8)).collect()
     }
 
-    #[tokio::test]
-    async fn test_get_snapshot_at_empty() {
-        let service_type = ServiceType::BlendNetwork;
-        let mut settings_per_service = HashMap::new();
-        settings_per_service.insert(
-            service_type,
-            MembershipBackendServiceSettings {
-                historical_block_delta: 10,
-            },
-        );
-
-        let settings = MockMembershipBackendSettings {
-            settings_per_service,
-            initial_membership: HashMap::new(),
-            initial_locators_mapping: HashMap::new(),
-            latest_block_number: 0,
-        };
-
-        let backend = MockMembershipBackend::init(settings);
-
-        // Test with empty membership
-        let result = backend.get_providers_at(service_type, 5).await.unwrap();
-        assert_eq!(result.1.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_get_snapshot_at_with_data() {
-        let service_type = ServiceType::BlendNetwork;
-
-        let provider_info_1 = create_provider_info(1, 100);
-        let provider_info_2 = create_provider_info(2, 100);
-
-        let declaration_update_1 = create_declaration_update(1, service_type, 3);
-        let declaration_update_2 = create_declaration_update(2, service_type, 3);
-
-        let provider_info_3 = create_provider_info(3, 100);
-        let declaration_update_3 = create_declaration_update(3, service_type, 3);
-
-        let mut settings_per_service = HashMap::new();
-        settings_per_service.insert(
-            service_type,
-            MembershipBackendServiceSettings {
-                historical_block_delta: 5,
-            },
-        );
-
-        let settings = MockMembershipBackendSettings {
-            settings_per_service,
-            initial_membership: HashMap::from([
-                (
-                    100,
-                    HashMap::from([(service_type, HashSet::from([provider_info_1.provider_id]))]),
-                ),
-                (
-                    101,
-                    HashMap::from([(
-                        service_type,
-                        HashSet::from([provider_info_1.provider_id, provider_info_2.provider_id]),
-                    )]),
-                ),
-                (
-                    102,
-                    HashMap::from([(
-                        service_type,
-                        HashSet::from([provider_info_1.provider_id, provider_info_3.provider_id]),
-                    )]),
-                ),
-            ]),
-            initial_locators_mapping: HashMap::from([
-                (
-                    provider_info_1.provider_id,
-                    BTreeSet::from_iter(declaration_update_1.locators.clone()),
-                ),
-                (
-                    provider_info_2.provider_id,
-                    BTreeSet::from_iter(declaration_update_2.locators.clone()),
-                ),
-                (
-                    provider_info_3.provider_id,
-                    BTreeSet::from_iter(declaration_update_3.locators.clone()),
-                ),
-            ]),
-            latest_block_number: 102,
-        };
-
-        let backend = MockMembershipBackend::init(settings);
-
-        // (1st entry)
-        // blocknumber 100 = 105 - k.historical_block_delta
-        let (_, providers) = backend.get_providers_at(service_type, 105).await.unwrap();
-
-        assert_eq!(providers.len(), 1);
-        assert!(providers.contains_key(&provider_info_1.provider_id));
-        assert_eq!(
-            providers.get(&provider_info_1.provider_id).unwrap(),
-            &BTreeSet::from_iter(declaration_update_1.locators.clone())
-        );
-
-        // (second entry)
-        // should have 1st and 2nd
-        let (_, providers) = backend.get_providers_at(service_type, 106).await.unwrap();
-        assert_eq!(providers.len(), 2);
-        assert!(providers.contains_key(&provider_info_1.provider_id));
-        assert!(providers.contains_key(&provider_info_2.provider_id));
-
-        assert_eq!(
-            providers.get(&provider_info_2.provider_id).unwrap(),
-            &BTreeSet::from_iter(declaration_update_2.locators)
-        );
-        assert_eq!(
-            providers.get(&provider_info_1.provider_id).unwrap(),
-            &BTreeSet::from_iter(declaration_update_1.locators.clone())
-        );
-
-        // (third entry)
-        // should have 1st and 3rd
-        let (_, providers) = backend.get_providers_at(service_type, 107).await.unwrap();
-        assert_eq!(providers.len(), 2);
-        assert!(providers.contains_key(&provider_info_1.provider_id));
-        assert!(providers.contains_key(&provider_info_3.provider_id));
-        assert_eq!(
-            providers.get(&provider_info_1.provider_id).unwrap(),
-            &BTreeSet::from_iter(declaration_update_1.locators.clone())
-        );
-        assert_eq!(
-            providers.get(&provider_info_3.provider_id).unwrap(),
-            &BTreeSet::from_iter(declaration_update_3.locators.clone())
-        );
-
-        // latest one should be same as the one we just added
-        let (_, providers) = backend.get_latest_providers(service_type).await.unwrap();
-        assert_eq!(providers.len(), 2);
-        assert!(providers.contains_key(&provider_info_1.provider_id));
-        assert!(providers.contains_key(&provider_info_3.provider_id));
-        assert_eq!(
-            providers.get(&provider_info_1.provider_id).unwrap(),
-            &BTreeSet::from_iter(declaration_update_1.locators)
-        );
-        assert_eq!(
-            providers.get(&provider_info_3.provider_id).unwrap(),
-            &BTreeSet::from_iter(declaration_update_3.locators)
-        );
-    }
-
-    // Helper functions outside the test
-    fn create_test_backend(service_type: ServiceType) -> MockMembershipBackend {
-        let mut settings_per_service = HashMap::new();
-        settings_per_service.insert(
-            service_type,
-            MembershipBackendServiceSettings {
-                historical_block_delta: 5,
-            },
-        );
-        MockMembershipBackend::init(MockMembershipBackendSettings {
-            settings_per_service,
-            initial_membership: HashMap::new(),
-            initial_locators_mapping: HashMap::new(),
-            latest_block_number: 0,
-        })
-    }
-
-    async fn update_and_assert(
-        backend: &mut MockMembershipBackend,
-        block_number: BlockNumber,
-        updates: Vec<FinalizedBlockEventUpdate>,
-        expected_providers: &[(ProviderId, Vec<Locator>)],
-        service_type: ServiceType,
-    ) {
-        let event = FinalizedBlockEvent {
-            block_number,
-            updates,
-        };
-        let result = backend.update(event).await.unwrap();
-        assert_update_result(&result, service_type, expected_providers);
-    }
-
-    fn create_block_update(
-        service_type: ServiceType,
+    fn update(
+        service: ServiceType,
         provider_id: ProviderId,
         state: DeclarationState,
-        locators: Vec<Locator>,
+        locators: BTreeSet<Locator>,
     ) -> FinalizedBlockEventUpdate {
         FinalizedBlockEventUpdate {
-            service_type,
+            service_type: service,
             provider_id,
             state,
-            locators: BTreeSet::from_iter(locators),
+            locators,
         }
     }
 
     #[tokio::test]
-    async fn test_update() {
-        let service_type = ServiceType::BlendNetwork;
-        let mut backend = create_test_backend(service_type);
+    async fn init_returns_seeded_session_zero() {
+        let service = ServiceType::DataAvailability;
 
-        // Create test data
-        let provider_info_1 = create_provider_info(1, 100);
-        let provider_info_2 = create_provider_info(2, 100);
-        let provider_info_3 = create_provider_info(3, 100);
+        // Seed session 0 with P1 and its locators
+        let p1 = pid(1);
+        let p1_locs = locs::<2>(1);
 
-        let decl_update_1 = create_declaration_update(1, service_type, 3);
-        let decl_update_2 = create_declaration_update(2, service_type, 3);
-        let decl_update_3 = create_declaration_update(3, service_type, 3);
+        let mut session0_membership: HashMap<ServiceType, HashSet<ProviderId>> = HashMap::new();
+        session0_membership.insert(service, HashSet::from([p1]));
 
-        // Test Phase 1: Add provider 1
-        update_and_assert(
-            &mut backend,
-            100,
-            vec![create_block_update(
-                service_type,
-                provider_info_1.provider_id,
-                DeclarationState::Active,
-                decl_update_1.locators.clone(),
-            )],
-            &[(provider_info_1.provider_id, decl_update_1.locators.clone())],
-            service_type,
-        )
-        .await;
-
-        // Test Phase 2: Add provider 2
-        update_and_assert(
-            &mut backend,
-            101,
-            vec![create_block_update(
-                service_type,
-                provider_info_2.provider_id,
-                DeclarationState::Active,
-                decl_update_2.locators.clone(),
-            )],
-            &[
-                (provider_info_1.provider_id, decl_update_1.locators.clone()),
-                (provider_info_2.provider_id, decl_update_2.locators.clone()),
-            ],
-            service_type,
-        )
-        .await;
-
-        // Test Phase 3: Remove provider 2, add provider 3
-        update_and_assert(
-            &mut backend,
-            102,
-            vec![
-                create_block_update(
-                    service_type,
-                    provider_info_2.provider_id,
-                    DeclarationState::Withdrawn,
-                    Vec::new(),
-                ),
-                create_block_update(
-                    service_type,
-                    provider_info_3.provider_id,
-                    DeclarationState::Active,
-                    decl_update_3.locators.clone(),
-                ),
-            ],
-            &[
-                (provider_info_1.provider_id, decl_update_1.locators),
-                (provider_info_3.provider_id, decl_update_3.locators),
-            ],
-            service_type,
-        )
-        .await;
-    }
-
-    fn assert_update_result(
-        result: &HashMap<ServiceType, MembershipProviders>,
-        service_type: ServiceType,
-        expected_providers: &[(ProviderId, Vec<Locator>)],
-    ) {
-        assert_eq!(
-            result.len(),
-            1,
-            "Result should contain exactly one service type"
-        );
-        assert!(
-            result.contains_key(&service_type),
-            "Result should contain the expected service type"
-        );
-
-        let (_, providers) = result.get(&service_type).unwrap();
-
-        // Only check providers that were part of this update
-        for (provider_id, expected_locators) in expected_providers {
-            assert!(
-                providers.contains_key(provider_id),
-                "Providers map should contain provider {provider_id:?}"
-            );
-            assert_eq!(
-                providers.get(provider_id).unwrap(),
-                &BTreeSet::from_iter(expected_locators.clone()),
-                "Locators for provider {provider_id:?} do not match expected",
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn test_update_missing_service_type() {
-        let service_type = ServiceType::BlendNetwork;
-        let unknown_service_type = ServiceType::DataAvailability;
-
-        let mut settings_per_service = HashMap::new();
-        settings_per_service.insert(
-            service_type,
-            MembershipBackendServiceSettings {
-                historical_block_delta: 5,
-            },
-        );
+        let session0_locators: HashMap<ProviderId, BTreeSet<Locator>> =
+            HashMap::from([(p1, p1_locs.clone())]);
 
         let settings = MockMembershipBackendSettings {
-            settings_per_service,
-            initial_membership: HashMap::new(),
-            initial_locators_mapping: HashMap::new(),
-            latest_block_number: 0,
+            session_size_blocks: 3,
+            session_zero_membership: session0_membership,
+            session_zero_locators_mapping: session0_locators,
+        };
+
+        let backend = MockMembershipBackend::init(settings);
+
+        // Active snapshot is seeded session 0
+        let (sid, providers) = backend.get_latest_providers(service).await.unwrap();
+        assert_eq!(sid, 0);
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers.get(&p1).unwrap(), &p1_locs);
+    }
+
+    #[tokio::test]
+    async fn forming_promotes_on_last_block_of_session() {
+        let service = ServiceType::DataAvailability;
+
+        // Session 0: P1 active
+        let p1 = pid(1);
+        let p1_locs = locs::<2>(1);
+
+        let mut session0_membership: HashMap<ServiceType, HashSet<ProviderId>> = HashMap::new();
+        session0_membership.insert(service, HashSet::from([p1]));
+
+        let session0_locators: HashMap<ProviderId, BTreeSet<Locator>> =
+            HashMap::from([(p1, p1_locs.clone())]);
+
+        // Small session size for easy boundary testing
+        let settings = MockMembershipBackendSettings {
+            session_size_blocks: 3, // blocks 0,1,2 => session 0; 3,4,5 => session 1; etc.
+            session_zero_membership: session0_membership,
+            session_zero_locators_mapping: session0_locators,
         };
 
         let mut backend = MockMembershipBackend::init(settings);
 
-        // unknown service type
-        let provider_info = create_provider_info(1, 5);
-        let declaration_update = create_declaration_update(1, unknown_service_type, 3);
+        // Forming session 1 updates across blocks 1..2 (still session 0 time)
+        let p2 = pid(2);
+        let p2_locs = locs::<3>(10);
 
-        let updates = vec![FinalizedBlockEventUpdate {
-            service_type: declaration_update.service,
-            provider_id: provider_info.provider_id,
-            state: DeclarationState::Active,
-            locators: BTreeSet::from_iter(declaration_update.locators),
-        }];
+        // Block 1: activate P2 (goes into forming S=1)
+        let ev1 = FinalizedBlockEvent {
+            block_number: 1,
+            updates: vec![update(
+                service,
+                p2,
+                DeclarationState::Active,
+                p2_locs.clone(),
+            )],
+        };
+        let r1 = backend.update(ev1).await.unwrap();
+        assert!(r1.is_none(), "No promotion before session boundary");
 
-        let event = FinalizedBlockEvent {
-            block_number: 5,
-            updates,
+        // Active snapshot still session 0 (only P1)
+        let (sid_a1, prov_a1) = backend.get_latest_providers(service).await.unwrap();
+        assert_eq!(sid_a1, 0);
+        assert_eq!(prov_a1.len(), 1);
+        assert!(prov_a1.contains_key(&p1));
+
+        // Block 2 (last block of session 0): withdraw P1 in forming; still in active
+        // until promotion
+        let ev2 = FinalizedBlockEvent {
+            block_number: 2,
+            updates: vec![update(
+                service,
+                p1,
+                DeclarationState::Withdrawn,
+                BTreeSet::new(),
+            )],
         };
 
-        let result = backend.update(event).await.unwrap();
-        assert_eq!(result.len(), 0);
+        // For block=2, block+1=3 -> 3/3==1 => forming_session_id==1 -> promote now.
+        let r2 = backend.update(ev2).await.unwrap();
+        let promoted = r2.expect("Promotion should occur at the end of session 0");
+
+        // The returned snapshot should be the new active (session 1) view
+        let (sid_promoted, prov_promoted) = promoted.get(&service).unwrap();
+        assert_eq!(*sid_promoted, 1);
+        assert_eq!(prov_promoted.len(), 1);
+        assert_eq!(prov_promoted.get(&p2).unwrap(), &p2_locs);
+
+        // And get_latest_providers must match the new active snapshot
+        let (sid_a2, prov_a2) = backend.get_latest_providers(service).await.unwrap();
+        assert_eq!(sid_a2, 1);
+        assert_eq!(prov_a2, *prov_promoted);
+    }
+
+    #[tokio::test]
+    async fn locators_are_replaced_before_promotion() {
+        let service = ServiceType::DataAvailability;
+
+        let p1 = pid(1);
+        let p1_locs_initial = locs::<1>(1);
+        let p1_locs_new = locs::<2>(21);
+
+        // Seed S=0 with P1
+        let mut session0_membership = HashMap::new();
+        session0_membership.insert(service, HashSet::from([p1]));
+        let session0_locators = HashMap::from([(p1, p1_locs_initial.clone())]);
+
+        let settings = MockMembershipBackendSettings {
+            session_size_blocks: 3, // blocks {0,1,2} -> S=0; boundary after block 2
+            session_zero_membership: session0_membership,
+            session_zero_locators_mapping: session0_locators,
+        };
+        let mut backend = MockMembershipBackend::init(settings);
+
+        // Block 1: update forming S=1, not yet boundary -> None
+        let r1 = backend
+            .update(FinalizedBlockEvent {
+                block_number: 1,
+                updates: vec![update(
+                    service,
+                    p1,
+                    DeclarationState::Active,
+                    p1_locs_new.clone(),
+                )],
+            })
+            .await
+            .unwrap();
+        assert!(r1.is_none(), "no promotion yet inside session");
+
+        // Block 2: end of S=0 -> promotion -> Some(...)
+        let r2 = backend
+            .update(FinalizedBlockEvent {
+                block_number: 2,
+                updates: vec![],
+            })
+            .await
+            .unwrap();
+
+        let promoted = r2.expect("promotion at end of session 0");
+        let (_, prov) = promoted.get(&service).unwrap();
+        assert_eq!(prov.get(&p1).unwrap(), &p1_locs_new);
+
+        // Latest reflects new locators
+        let (_, latest) = backend.get_latest_providers(service).await.unwrap();
+        assert_eq!(latest.get(&p1).unwrap(), &p1_locs_new);
+    }
+
+    #[tokio::test]
+    async fn block_from_past_is_rejected() {
+        let settings = MockMembershipBackendSettings {
+            session_size_blocks: 3,
+            session_zero_membership: HashMap::new(),
+            session_zero_locators_mapping: HashMap::new(),
+        };
+
+        let mut backend = MockMembershipBackend::init(settings);
+
+        let ok = backend
+            .update(FinalizedBlockEvent {
+                block_number: 10,
+                updates: vec![],
+            })
+            .await;
+        assert!(ok.is_ok());
+
+        // Same block number again -> should fail with BlockFromPast
+        let err = backend
+            .update(FinalizedBlockEvent {
+                block_number: 10,
+                updates: vec![],
+            })
+            .await
+            .unwrap_err();
+
+        match err {
+            MembershipBackendError::BlockFromPast => {}
+            MembershipBackendError::Other(err) => panic!("Expected BlockFromPast, got {err}"),
+        }
     }
 }

--- a/nomos-services/membership/src/backends/mod.rs
+++ b/nomos-services/membership/src/backends/mod.rs
@@ -1,26 +1,13 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use nomos_core::{
-    block::BlockNumber,
-    sdp::{FinalizedBlockEvent, ServiceType},
-};
+use nomos_core::sdp::{FinalizedBlockEvent, ServiceType};
 use overwatch::DynError;
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::MembershipProviders;
 
 pub mod mock;
-
-pub struct MembershipBackendSettings {
-    pub settings_per_service: HashMap<ServiceType, MembershipBackendServiceSettings>,
-}
-
-#[derive(Clone, Debug, Copy, Serialize, Deserialize)]
-pub struct MembershipBackendServiceSettings {
-    pub historical_block_delta: u64,
-}
 
 #[derive(Debug, Error)]
 pub enum MembershipBackendError {
@@ -31,16 +18,13 @@ pub enum MembershipBackendError {
     BlockFromPast,
 }
 
+pub type NewSesssion = Option<HashMap<ServiceType, MembershipProviders>>;
+
 #[async_trait]
 pub trait MembershipBackend {
     type Settings: Send + Sync;
 
     fn init(settings: Self::Settings) -> Self;
-    async fn get_providers_at(
-        &self,
-        service_type: ServiceType,
-        block_number: BlockNumber,
-    ) -> Result<MembershipProviders, MembershipBackendError>;
 
     async fn get_latest_providers(
         &self,
@@ -50,5 +34,5 @@ pub trait MembershipBackend {
     async fn update(
         &mut self,
         update: FinalizedBlockEvent,
-    ) -> Result<HashMap<ServiceType, MembershipProviders>, MembershipBackendError>;
+    ) -> Result<NewSesssion, MembershipBackendError>;
 }

--- a/nomos-services/membership/src/lib.rs
+++ b/nomos-services/membership/src/lib.rs
@@ -41,11 +41,6 @@ pub struct MembershipServiceSettings<BackendSettings> {
 }
 
 pub enum MembershipMessage {
-    GetSnapshotAt {
-        reply_channel: oneshot::Sender<Result<MembershipProviders, MembershipBackendError>>,
-        block_number: BlockNumber,
-        service_type: nomos_core::sdp::ServiceType,
-    },
     Subscribe {
         service_type: nomos_core::sdp::ServiceType,
         result_sender: oneshot::Sender<Result<MembershipSnapshotStream, MembershipBackendError>>,
@@ -172,19 +167,6 @@ where
     )]
     async fn handle_message(&mut self, msg: MembershipMessage) {
         match msg {
-            MembershipMessage::GetSnapshotAt {
-                reply_channel,
-                block_number,
-                service_type,
-            } => {
-                let result = self
-                    .backend
-                    .get_providers_at(service_type, block_number)
-                    .await;
-                if let Err(e) = reply_channel.send(result) {
-                    tracing::error!("Failed to send response: {:?}", e);
-                }
-            }
             MembershipMessage::Subscribe {
                 service_type,
                 result_sender,
@@ -250,6 +232,13 @@ where
     async fn handle_sdp_update(&mut self, sdp_msg: nomos_core::sdp::FinalizedBlockEvent) {
         match self.backend.update(sdp_msg).await {
             Ok(snapshot) => {
+                if snapshot.is_none() {
+                    // no new sessions
+                    return;
+                }
+
+                let snapshot = snapshot.unwrap();
+                
                 // The list of all providers for each updated service type is sent to
                 // appropriate subscribers per service type
                 for (service_type, snapshot) in snapshot {

--- a/testnet/cfgsync/src/config.rs
+++ b/testnet/cfgsync/src/config.rs
@@ -8,10 +8,7 @@ use std::{
 use nomos_blend_scheduling::membership::Node;
 use nomos_core::sdp::{Locator, ServiceType};
 use nomos_libp2p::{ed25519, multiaddr, Multiaddr, PeerId};
-use nomos_membership::{
-    backends::{mock::MockMembershipBackendSettings, MembershipBackendServiceSettings},
-    MembershipServiceSettings,
-};
+use nomos_membership::{backends::mock::MockMembershipBackendSettings, MembershipServiceSettings};
 use nomos_tracing_service::{LoggerLayer, MetricsLayer, TracingLayer, TracingSettings};
 use rand::{thread_rng, Rng as _};
 use tests::{
@@ -220,13 +217,6 @@ fn update_tracing_identifier(
 
 #[must_use]
 pub fn create_membership_configs(ids: &[[u8; 32]], hosts: &[Host]) -> Vec<GeneralMembershipConfig> {
-    let settings_per_service = HashMap::from([(
-        ServiceType::DataAvailability,
-        MembershipBackendServiceSettings {
-            historical_block_delta: 8,
-        },
-    )]);
-
     let mut provider_ids = vec![];
     let mut locators = HashMap::new();
 
@@ -247,7 +237,6 @@ pub fn create_membership_configs(ids: &[[u8; 32]], hosts: &[Host]) -> Vec<Genera
         locators.insert(provider_id, Locator::new(listening_address));
     }
 
-    let mut initial_membership = HashMap::new();
     let mut initial_locators_mapping = HashMap::new();
     let mut membership_entry = HashMap::new();
     let mut providers = HashSet::new();
@@ -257,7 +246,6 @@ pub fn create_membership_configs(ids: &[[u8; 32]], hosts: &[Host]) -> Vec<Genera
     }
 
     membership_entry.insert(ServiceType::DataAvailability, providers.clone());
-    initial_membership.insert(0u64, membership_entry);
 
     for provider_id in providers {
         let mut locs = BTreeSet::new();
@@ -268,10 +256,9 @@ pub fn create_membership_configs(ids: &[[u8; 32]], hosts: &[Host]) -> Vec<Genera
     }
 
     let mock_backend_settings = MockMembershipBackendSettings {
-        settings_per_service,
-        initial_membership,
-        initial_locators_mapping,
-        latest_block_number: 0,
+        session_size_blocks: 1,
+        session_zero_membership: membership_entry,
+        session_zero_locators_mapping: initial_locators_mapping,
     };
 
     let config = GeneralMembershipConfig {

--- a/tests/src/tests/da/api.rs
+++ b/tests/src/tests/da/api.rs
@@ -76,15 +76,13 @@ async fn test_block_peer() {
         .config()
         .membership
         .backend
-        .initial_membership
-        .get(&0)
-        .expect("Expected at least one membership entry");
+        .session_zero_membership
+        .get(&nomos_core::sdp::ServiceType::DataAvailability)
+        .expect("Expected data availability membership");
     assert!(!membership.is_empty());
 
     // take second peer ID from the membership set
     let existing_provider_id = *membership
-        .get(&nomos_core::sdp::ServiceType::DataAvailability)
-        .expect("Expected at least one provider ID in the membership set")
         .iter()
         .nth(1)
         .expect("Expected at least two provider IDs in the membership set");

--- a/tests/src/tests/membership/api.rs
+++ b/tests/src/tests/membership/api.rs
@@ -16,11 +16,9 @@ async fn test_update_get_membership_http() {
         .config()
         .membership
         .backend
-        .initial_membership
-        .get(&0)
-        .expect("Expected at least one membership entry")
+        .session_zero_membership
         .get(&nomos_core::sdp::ServiceType::DataAvailability)
-        .expect("Expected at least one provider ID in the membership set")
+        .expect("Expected data availability membership")
         .iter()
         .next()
         .expect("Expected at least one provider ID in the membership set");

--- a/tests/src/tests/membership/disperse.rs
+++ b/tests/src/tests/membership/disperse.rs
@@ -27,54 +27,51 @@ async fn update_membership_and_dissiminate() {
 
     let topology = Topology::spawn_with_empty_membership(topology_config, &ids, &ports).await;
 
-    let non_empty_membership = create_membership_configs(&ids, &ports)[0].clone();
+    let non_empty_membership_configs = create_membership_configs(&ids, &ports)[0].clone();
 
-    for (block_number, members) in non_empty_membership
+    let non_zero_membership = non_empty_membership_configs
         .service_settings
         .backend
-        .initial_membership
-    {
-        let mut finalized_block_event_updates = vec![];
-        let providers = members
-            .get(&nomos_core::sdp::ServiceType::DataAvailability)
-            .expect("Expected at least one provider ID in the membership set")
+        .session_zero_membership
+        .get(&nomos_core::sdp::ServiceType::DataAvailability)
+        .expect("Expected data availability membership");
+
+    let mut finalized_block_event_updates = vec![];
+
+    for provider in non_zero_membership {
+        let locators = non_empty_membership_configs
+            .service_settings
+            .backend
+            .session_zero_locators_mapping
+            .get(provider)
+            .expect("Expected locators for provider")
             .clone();
 
-        for provider in providers {
-            let locators = non_empty_membership
-                .service_settings
-                .backend
-                .initial_locators_mapping
-                .get(&provider)
-                .unwrap()
-                .clone();
+        finalized_block_event_updates.push(FinalizedBlockEventUpdate {
+            service_type: nomos_core::sdp::ServiceType::DataAvailability,
+            provider_id: *provider,
+            state: nomos_core::sdp::DeclarationState::Active,
+            locators,
+        });
+    }
 
-            finalized_block_event_updates.push(FinalizedBlockEventUpdate {
-                service_type: nomos_core::sdp::ServiceType::DataAvailability,
-                provider_id: provider,
-                state: nomos_core::sdp::DeclarationState::Active,
-                locators,
-            });
-        }
+    let finalize_block_event = FinalizedBlockEvent {
+        block_number: 1,
+        updates: finalized_block_event_updates.clone(),
+    };
 
-        let finalize_block_event = FinalizedBlockEvent {
-            block_number: block_number + 1,
-            updates: finalized_block_event_updates.clone(),
-        };
+    for validator in topology.validators() {
+        let res = validator
+            .update_membership(finalize_block_event.clone())
+            .await;
+        assert!(res.is_ok(), "Failed to update membership on validator");
+    }
 
-        for validator in topology.validators() {
-            let res = validator
-                .update_membership(finalize_block_event.clone())
-                .await;
-            assert!(res.is_ok(), "Failed to update membership on validator");
-        }
-
-        for executor in topology.executors() {
-            let res = executor
-                .update_membership(finalize_block_event.clone())
-                .await;
-            assert!(res.is_ok(), "Failed to update membership on executor");
-        }
+    for executor in topology.executors() {
+        let res = executor
+            .update_membership(finalize_block_event.clone())
+            .await;
+        assert!(res.is_ok(), "Failed to update membership on executor");
     }
 
     let executor = &topology.executors()[0];

--- a/tests/src/topology/configs/membership.rs
+++ b/tests/src/topology/configs/membership.rs
@@ -5,10 +5,7 @@ use std::{
 
 use nomos_core::sdp::{Locator, ServiceType};
 use nomos_libp2p::{ed25519, Multiaddr};
-use nomos_membership::{
-    backends::{mock::MockMembershipBackendSettings, MembershipBackendServiceSettings},
-    MembershipServiceSettings,
-};
+use nomos_membership::{backends::mock::MockMembershipBackendSettings, MembershipServiceSettings};
 use serde::{Deserialize, Serialize};
 
 use crate::secret_key_to_provider_id;
@@ -20,13 +17,6 @@ pub struct GeneralMembershipConfig {
 
 #[must_use]
 pub fn create_membership_configs(ids: &[[u8; 32]], ports: &[u16]) -> Vec<GeneralMembershipConfig> {
-    let settings_per_service = HashMap::from([(
-        ServiceType::DataAvailability,
-        MembershipBackendServiceSettings {
-            historical_block_delta: 8,
-        },
-    )]);
-
     let mut provider_ids = vec![];
     let mut locators = HashMap::new();
 
@@ -45,17 +35,15 @@ pub fn create_membership_configs(ids: &[[u8; 32]], ports: &[u16]) -> Vec<General
         locators.insert(provider_id, Locator::new(listening_address));
     }
 
-    let mut initial_membership = HashMap::new();
     let mut initial_locators_mapping = HashMap::new();
-    let mut membership_entry = HashMap::new();
+    let mut initial_membership = HashMap::new();
     let mut providers = HashSet::new();
 
     for provider_id in provider_ids {
         providers.insert(provider_id);
     }
 
-    membership_entry.insert(ServiceType::DataAvailability, providers.clone());
-    initial_membership.insert(0u64, membership_entry);
+    initial_membership.insert(ServiceType::DataAvailability, providers.clone());
 
     for provider_id in providers {
         let mut locs = BTreeSet::new();
@@ -66,10 +54,9 @@ pub fn create_membership_configs(ids: &[[u8; 32]], ports: &[u16]) -> Vec<General
     }
 
     let mock_backend_settings = MockMembershipBackendSettings {
-        settings_per_service,
-        initial_membership,
-        initial_locators_mapping,
-        latest_block_number: 0,
+        session_size_blocks: 1,
+        session_zero_membership: initial_membership,
+        session_zero_locators_mapping: initial_locators_mapping,
     };
 
     let config = GeneralMembershipConfig {
@@ -85,21 +72,13 @@ pub fn create_membership_configs(ids: &[[u8; 32]], ports: &[u16]) -> Vec<General
 pub fn create_empty_membership_configs(n_participants: usize) -> Vec<GeneralMembershipConfig> {
     let mut membership_configs = vec![];
 
-    let settings_per_service = HashMap::from([(
-        ServiceType::DataAvailability,
-        MembershipBackendServiceSettings {
-            historical_block_delta: 8,
-        },
-    )]);
-
     for _ in 0..n_participants {
         membership_configs.push(GeneralMembershipConfig {
             service_settings: MembershipServiceSettings {
                 backend: MockMembershipBackendSettings {
-                    settings_per_service: settings_per_service.clone(),
-                    initial_membership: HashMap::new(),
-                    initial_locators_mapping: HashMap::new(),
-                    latest_block_number: 0,
+                    session_size_blocks: 1,
+                    session_zero_membership: HashMap::new(),
+                    session_zero_locators_mapping: HashMap::new(),
                 },
             },
         });


### PR DESCRIPTION
…p implementation

## 1. What does this PR implement?

This PR implements session forming in membership backend mock implementation. Mock implementation is not storing the current state so it can resume in the case of recovery, but should cover the whole business logic.

In order for downwards code to compile (da network assignations) that depends on block number, the session id is passed downstream as blocknumber, and session size is 1 block in tests for them to pass. This enables us to open several PR for this without conflicts and test the whole chain in the end.

So the following PRs should promote session id downstream (might be trivial just block number -> session ID) and add tests for session size > 1 block.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
