### PR TITLE
chore: Add error enum for `nomos-libp2p`

### DIFF
--- a/nomos-libp2p/src/behaviour/mod.rs
+++ b/nomos-libp2p/src/behaviour/mod.rs
@@ -3,8 +3,6 @@
     reason = "We split the `Behaviour` impls into different modules for better code modularity."
 )]
 
-use std::error::Error;
-
 use cryptarchia_sync::ChainSyncError;
 use libp2p::{identity, kad, swarm::NetworkBehaviour, PeerId};
 use thiserror::Error;
@@ -47,7 +45,7 @@ impl Behaviour {
         chain_sync_config: cryptarchia_sync::Config,
         protocol_name: ProtocolName,
         public_key: identity::PublicKey,
-    ) -> Result<Self, Box<dyn Error>> {
+    ) -> crate::Result<Self> {
         let peer_id = PeerId::from(public_key.clone());
         let gossipsub = libp2p::gossipsub::Behaviour::new(
             libp2p::gossipsub::MessageAuthenticity::Author(peer_id),
@@ -56,7 +54,8 @@ impl Behaviour {
                 .message_id_fn(compute_message_id)
                 .max_transmit_size(DATA_LIMIT)
                 .build()?,
-        )?;
+        )
+        .map_err(|err| crate::Error::BehaviourError(err))?;
 
         let identify = libp2p::identify::Behaviour::new(
             identify_config.to_libp2p_config(public_key, protocol_name),

--- a/nomos-libp2p/src/error.rs
+++ b/nomos-libp2p/src/error.rs
@@ -1,0 +1,33 @@
+use crate::gossipsub::ConfigBuilderError;
+use libp2p::TransportError;
+
+/// Local errors
+#[derive(Debug)]
+pub enum Error {
+    /// Couldn't create gossip from parameters.
+    BehaviourError(&'static str),
+    /// See [`ConfigBuilderError`].
+    ConfigBuilderError(ConfigBuilderError),
+    /// See [`std::io::Error`].
+    Io(std::io::Error),
+    /// See [`TransportError`].
+    TransportError(TransportError<std::io::Error>),
+}
+
+impl From<ConfigBuilderError> for Error {
+    fn from(from: ConfigBuilderError) -> Self {
+        Self::ConfigBuilderError(from)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(from: std::io::Error) -> Self {
+        Self::Io(from)
+    }
+}
+
+impl From<TransportError<std::io::Error>> for Error {
+    fn from(from: TransportError<std::io::Error>) -> Self {
+        Self::TransportError(from)
+    }
+}

--- a/nomos-libp2p/src/lib.rs
+++ b/nomos-libp2p/src/lib.rs
@@ -1,9 +1,12 @@
 pub mod behaviour;
 mod config;
+mod error;
 pub mod protocol_name;
 mod swarm;
 
+pub use crate::swarm::*;
 pub use config::{secret_key_serde, IdentifySettings, KademliaSettings, SwarmConfig};
+pub use error::Error;
 pub use libp2p::{
     self,
     core::upgrade,
@@ -14,4 +17,5 @@ pub use libp2p::{
 };
 pub use multiaddr::{multiaddr, Multiaddr, Protocol};
 
-pub use crate::swarm::*;
+/// Alias that uses the local error
+pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes a TODO