### PR TITLE
feat(blend): introduce redundancy factor for edge nodes

### DIFF
--- a/nodes/nomos-node/node/src/config/blend.rs
+++ b/nodes/nomos-node/node/src/config/blend.rs
@@ -22,6 +22,10 @@ impl BlendConfig {
                     .try_into()
                     .expect("Max dial attempts per peer per message cannot be zero."),
                 protocol_name: self.0.backend.protocol_name.clone(),
+                // TODO: Allow for edge service settings to be included here.
+                replication_factor: 4
+                    .try_into()
+                    .expect("Edge message replication factor cannot be zero."),
             },
             crypto: self.0.crypto.clone(),
             time: self.0.time.clone(),

--- a/nomos-services/blend/src/edge/backends/libp2p/settings.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/settings.rs
@@ -15,6 +15,9 @@ pub struct Libp2pBlendBackendSettings {
     pub node_key: ed25519::SecretKey,
     pub max_dial_attempts_per_peer_per_message: NonZeroU64,
     pub protocol_name: StreamProtocol,
+    // $\Phi_{EC}$: the minimum number of connections that the edge node establishes with
+    // core nodes to send a single message that needs to be blended.
+    pub replication_factor: NonZeroU64,
 }
 
 impl Libp2pBlendBackendSettings {

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/message_handling.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/message_handling.rs
@@ -2,7 +2,7 @@ use core::{slice::from_ref, time::Duration};
 
 use nomos_blend_scheduling::membership::Membership;
 use test_log::test;
-use tokio::{spawn, time::sleep};
+use tokio::{select, spawn, time::sleep};
 
 use crate::{
     core::backends::libp2p::core_swarm_test_utils::{
@@ -58,6 +58,9 @@ async fn edge_message_propagation() {
         swarm: edge_swarm,
         command_sender: edge_swarm_command_sender,
     } = EdgeSwarmBuilder::default()
+        // We test that we can pick the `min` between the propagation factor and the available
+        // peers.
+        .with_propagation_factor(usize::MAX)
         .with_membership(membership_for_edge_swarm)
         .build();
     spawn(async move { edge_swarm.run().await });
@@ -76,4 +79,110 @@ async fn edge_message_propagation() {
 
     assert_eq!(swarm_1_received_message.into_inner(), message.clone());
     assert_eq!(swarm_2_received_message.into_inner(), message.clone());
+}
+
+#[test(tokio::test)]
+async fn propagation_factor() {
+    let CoreTestSwarm {
+        swarm: mut core_swarm_1,
+        incoming_message_receiver: mut core_swarm_1_incoming_message_receiver,
+        ..
+    } = CoreSwarmBuilder::default()
+        .with_empty_membership()
+        .build(|id| {
+            BlendBehaviourBuilder::new(&id)
+                .with_empty_membership()
+                .build()
+        });
+    let (swarm_1_membership_entry, _) = core_swarm_1.listen_and_return_membership_entry(None).await;
+
+    let CoreTestSwarm {
+        swarm: mut core_swarm_2,
+        incoming_message_receiver: mut core_swarm_2_incoming_message_receiver,
+        ..
+    } = CoreSwarmBuilder::default()
+        .with_empty_membership()
+        .build(|id| {
+            BlendBehaviourBuilder::new(&id)
+                .with_empty_membership()
+                .build()
+        });
+    let (swarm_2_membership_entry, _) = core_swarm_2.listen_and_return_membership_entry(None).await;
+
+    let CoreTestSwarm {
+        swarm: mut core_swarm_3,
+        incoming_message_receiver: mut core_swarm_3_incoming_message_receiver,
+        ..
+    } = CoreSwarmBuilder::default()
+        .with_empty_membership()
+        .build(|id| {
+            BlendBehaviourBuilder::new(&id)
+                .with_empty_membership()
+                .build()
+        });
+    let (swarm_3_membership_entry, _) = core_swarm_3.listen_and_return_membership_entry(None).await;
+
+    spawn(async move { core_swarm_1.run().await });
+    spawn(async move { core_swarm_2.run().await });
+    spawn(async move { core_swarm_3.run().await });
+
+    // We pass all 3 swarms to the edge swarm, and we test that only 2 of them
+    // (propagation factor) are picked.
+    let membership_for_edge_swarm = Membership::new(
+        &[
+            swarm_1_membership_entry,
+            swarm_2_membership_entry,
+            swarm_3_membership_entry,
+        ],
+        None,
+    );
+    let EdgeTestSwarm {
+        swarm: edge_swarm,
+        command_sender: edge_swarm_command_sender,
+    } = EdgeSwarmBuilder::default()
+        .with_membership(membership_for_edge_swarm)
+        .with_propagation_factor(2)
+        .build();
+    spawn(async move { edge_swarm.run().await });
+
+    // Send message
+    let message = TestEncapsulatedMessage::new(b"test-payload");
+    edge_swarm_command_sender
+        .send(Command::SendMessage(message.clone()))
+        .await
+        .unwrap();
+
+    let mut received_messages = 0u8;
+    let mut swarm_1_message_received = false;
+    let mut swarm_2_message_received = false;
+    let mut swarm_3_message_received = false;
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(5)) => {
+                break;
+            }
+            swarm_1_received_message = core_swarm_1_incoming_message_receiver.recv() => {
+                assert_eq!(swarm_1_received_message.unwrap().into_inner(), message.clone());
+                assert!(!swarm_1_message_received);
+                received_messages += 1;
+                swarm_1_message_received = true;
+            }
+            swarm_2_received_message = core_swarm_2_incoming_message_receiver.recv() => {
+                assert_eq!(swarm_2_received_message.unwrap().into_inner(), message.clone());
+                assert!(!swarm_2_message_received);
+                received_messages += 1;
+                swarm_2_message_received = true;
+            }
+            swarm_3_received_message = core_swarm_3_incoming_message_receiver.recv() => {
+                assert_eq!(swarm_3_received_message.unwrap().into_inner(), message.clone());
+                assert!(!swarm_3_message_received);
+                received_messages += 1;
+                swarm_3_message_received = true;
+            }
+        }
+    }
+
+    // Verify that only 2 out of 3 (unconnected) core swarms receive the message.
+    assert_eq!(received_messages, 2);
+    assert!(!swarm_1_message_received || !swarm_2_message_received || !swarm_3_message_received);
 }

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/message_handling.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/message_handling.rs
@@ -58,9 +58,9 @@ async fn edge_message_propagation() {
         swarm: edge_swarm,
         command_sender: edge_swarm_command_sender,
     } = EdgeSwarmBuilder::default()
-        // We test that we can pick the `min` between the propagation factor and the available
+        // We test that we can pick the `min` between the replication factor and the available
         // peers.
-        .with_propagation_factor(usize::MAX)
+        .with_replication_factor(usize::MAX)
         .with_membership(membership_for_edge_swarm)
         .build();
     spawn(async move { edge_swarm.run().await });
@@ -82,7 +82,7 @@ async fn edge_message_propagation() {
 }
 
 #[test(tokio::test)]
-async fn propagation_factor() {
+async fn replication_factor() {
     let CoreTestSwarm {
         swarm: mut core_swarm_1,
         incoming_message_receiver: mut core_swarm_1_incoming_message_receiver,
@@ -127,7 +127,7 @@ async fn propagation_factor() {
     spawn(async move { core_swarm_3.run().await });
 
     // We pass all 3 swarms to the edge swarm, and we test that only 2 of them
-    // (propagation factor) are picked.
+    // (replication factor) are picked.
     let membership_for_edge_swarm = Membership::new(
         &[
             swarm_1_membership_entry,
@@ -141,7 +141,7 @@ async fn propagation_factor() {
         command_sender: edge_swarm_command_sender,
     } = EdgeSwarmBuilder::default()
         .with_membership(membership_for_edge_swarm)
-        .with_propagation_factor(2)
+        .with_replication_factor(2)
         .build();
     spawn(async move { edge_swarm.run().await });
 

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/redials.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/redials.rs
@@ -35,7 +35,7 @@ async fn edge_redial_same_peer() {
         ))
         .build();
     let message = TestEncapsulatedMessage::new(b"test-payload");
-    swarm.send_message(message.clone());
+    swarm.send_message(&message);
 
     let dial_attempt_1_record = swarm
         .pending_dials()
@@ -156,7 +156,7 @@ async fn edge_redial_different_peer_after_redial_limit() {
 
     // We instruct the swarm to try to dial the unreachable swarm first by excluding
     // the core swarm from the initial set of recipients.
-    edge_swarm.send_message_to_anyone_except(*core_swarm.local_peer_id(), message.clone());
+    edge_swarm.send_message_to_anyone_except(*core_swarm.local_peer_id(), &message);
 
     spawn(async move { core_swarm.run().await });
     spawn(async move { edge_swarm.run().await });

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/utils.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/utils.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 use futures::stream::{pending, Pending};
 use libp2p::PeerId;
 use nomos_blend_scheduling::membership::Membership;
@@ -18,11 +20,17 @@ pub struct TestSwarm {
 #[derive(Default)]
 pub struct SwarmBuilder {
     membership: Option<Membership<PeerId>>,
+    propagation_factor: Option<NonZeroUsize>,
 }
 
 impl SwarmBuilder {
     pub fn with_membership(mut self, membership: Membership<PeerId>) -> Self {
         self.membership = Some(membership);
+        self
+    }
+
+    pub fn with_propagation_factor(mut self, propagation_factor: usize) -> Self {
+        self.propagation_factor = Some(propagation_factor.try_into().unwrap());
         self
     }
 
@@ -36,6 +44,8 @@ impl SwarmBuilder {
             BlakeRng::from_entropy(),
             pending(),
             PROTOCOL_NAME,
+            self.propagation_factor
+                .unwrap_or_else(|| 1usize.try_into().unwrap()),
         );
 
         TestSwarm {

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/utils.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/utils.rs
@@ -20,7 +20,7 @@ pub struct TestSwarm {
 #[derive(Default)]
 pub struct SwarmBuilder {
     membership: Option<Membership<PeerId>>,
-    propagation_factor: Option<NonZeroUsize>,
+    replication_factor: Option<NonZeroUsize>,
 }
 
 impl SwarmBuilder {
@@ -29,8 +29,8 @@ impl SwarmBuilder {
         self
     }
 
-    pub fn with_propagation_factor(mut self, propagation_factor: usize) -> Self {
-        self.propagation_factor = Some(propagation_factor.try_into().unwrap());
+    pub fn with_replication_factor(mut self, replication_factor: usize) -> Self {
+        self.replication_factor = Some(replication_factor.try_into().unwrap());
         self
     }
 
@@ -44,7 +44,7 @@ impl SwarmBuilder {
             BlakeRng::from_entropy(),
             pending(),
             PROTOCOL_NAME,
-            self.propagation_factor
+            self.replication_factor
                 .unwrap_or_else(|| 1usize.try_into().unwrap()),
         );
 


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes https://github.com/logos-co/nomos/issues/1502 (see issue comments for why this PR alone is sufficient to fix the issue). For more context about the meaning of the redundancy parameter, refer to the [Discord thread](https://discord.com/channels/1111286067413405788/1410163003999125524).

The only thing I did not implement in here, because I do not think the gains justify the additional overhead, is to keep track of what peers are being sent each message, so that when a dialing with a peer for a given message fails, we avoid picking up a peer we have already sent the same message to. Nevertheless, since edge nodes are not banned and core nodes simply discard duplicated messages, I do not think it's a big issue. Also, since Blend is not meant to run for sets smaller than 32 elements, the chances of this happening for a message are small. For all the copies of the same message much smaller.
Tackling this would involve having one more storage map mapping from a message to a set of peers currently receiving it, that we can clear once all peers have successfully received a message. We could argue that is worth implementing, but otherwise I would only do it if we see that this becomes a problem in the future, but I don't think that will be the case.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

Spec: @madxor, impl: @ntn-x2, review: @youngjoon-lee.

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

It introduced minor changes to improve clarity around what an edge node is supposed to do. Refer to the Discord thread linked above for more context.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
