### PR TITLE
feat(da-network): historic sampling behavior and service glue

### DIFF
--- a/nomos-da/network/core/src/protocols/sampling/errors.rs
+++ b/nomos-da/network/core/src/protocols/sampling/errors.rs
@@ -184,3 +184,11 @@ impl Clone for SamplingError {
         }
     }
 }
+
+#[derive(Error, Debug, Clone)]
+pub enum HistoricSamplingError {
+    #[error("Historic sampling failed")]
+    SamplingFailed,
+    #[error("Internal server error: {0}")]
+    InternalServerError(String),
+}

--- a/nomos-da/network/core/src/protocols/sampling/historic/mod.rs
+++ b/nomos-da/network/core/src/protocols/sampling/historic/mod.rs
@@ -1,8 +1,9 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use kzgrs_backend::common::share::{DaLightShare, DaSharesCommitments};
-use nomos_core::header::HeaderId;
-use thiserror::Error;
+use nomos_core::{da::BlobId, header::HeaderId};
+
+use crate::protocols::sampling::errors::HistoricSamplingError;
 
 pub mod request_behaviour;
 
@@ -10,19 +11,11 @@ pub mod request_behaviour;
 pub enum HistoricSamplingEvent {
     SamplingSuccess {
         block_id: HeaderId,
-        commitments: HashSet<DaSharesCommitments>,
-        shares: HashSet<DaLightShare>,
+        commitments: HashMap<BlobId, DaSharesCommitments>,
+        shares: HashMap<BlobId, Vec<DaLightShare>>,
     },
     SamplingError {
         block_id: HeaderId,
         error: HistoricSamplingError,
     },
-}
-
-#[derive(Error, Debug)]
-pub enum HistoricSamplingError {
-    #[error("Historic sampling failed")]
-    SamplingFailed,
-    #[error("Internal server error: {0}")]
-    InternalServerError(String),
 }

--- a/nomos-da/network/core/src/protocols/sampling/mod.rs
+++ b/nomos-da/network/core/src/protocols/sampling/mod.rs
@@ -5,7 +5,7 @@ mod requests;
 mod responses;
 mod streams;
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use errors::SamplingError;
 use futures::{
@@ -27,7 +27,8 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     addressbook::AddressBookHandler,
     protocols::sampling::{
-        historic::{request_behaviour::HistoricRequestSamplingBehaviour, HistoricSamplingError},
+        errors::HistoricSamplingError,
+        historic::request_behaviour::HistoricRequestSamplingBehaviour,
         requests::request_behaviour::RequestSamplingBehaviour,
         responses::response_behaviour::ResponseSamplingBehaviour,
     },
@@ -137,8 +138,8 @@ pub enum SamplingEvent {
     },
     HistoricSamplingSuccess {
         block_id: HeaderId,
-        shares: HashSet<DaLightShare>,
-        commitments: HashSet<DaSharesCommitments>,
+        shares: HashMap<BlobId, Vec<DaLightShare>>,
+        commitments: HashMap<BlobId, DaSharesCommitments>,
     },
     CommitmentsSuccess {
         blob_id: BlobId,

--- a/nomos-services/data-availability/dispersal/src/adapters/network/libp2p.rs
+++ b/nomos-services/data-availability/dispersal/src/adapters/network/libp2p.rs
@@ -181,7 +181,8 @@ where
                     match event {
                         DaNetworkEvent::Sampling(_)
                         | DaNetworkEvent::Commitments(_)
-                        | DaNetworkEvent::Verifying(_) => None,
+                        | DaNetworkEvent::Verifying(_)
+                        | DaNetworkEvent::HistoricSampling(_) => None,
                         DaNetworkEvent::Dispersal(DispersalExecutorEvent::DispersalError {
                             error,
                         }) => Some(Err(Box::new(error) as DynError)),

--- a/nomos-services/data-availability/network/src/backends/libp2p/validator.rs
+++ b/nomos-services/data-availability/network/src/backends/libp2p/validator.rs
@@ -28,7 +28,8 @@ use crate::{
         libp2p::common::{
             handle_balancer_command, handle_historic_sample_request, handle_monitor_command,
             handle_sample_request, handle_validator_events_stream, CommitmentsEvent,
-            DaNetworkBackendSettings, SamplingEvent, VerificationEvent, BROADCAST_CHANNEL_SIZE,
+            DaNetworkBackendSettings, HistoricSamplingEvent, SamplingEvent, VerificationEvent,
+            BROADCAST_CHANNEL_SIZE,
         },
         NetworkBackend,
     },
@@ -61,6 +62,7 @@ pub enum DaNetworkEventKind {
     Sampling,
     Commitments,
     Verifying,
+    HistoricSampling,
 }
 
 /// DA network incoming events
@@ -69,6 +71,7 @@ pub enum DaNetworkEvent {
     Sampling(SamplingEvent),
     Commitments(CommitmentsEvent),
     Verifying(VerificationEvent),
+    HistoricSampling(HistoricSamplingEvent),
 }
 
 /// DA network backend for validators
@@ -87,6 +90,7 @@ pub struct DaNetworkValidatorBackend<Membership> {
     sampling_broadcast_receiver: broadcast::Receiver<SamplingEvent>,
     commitments_broadcast_receiver: broadcast::Receiver<CommitmentsEvent>,
     verifying_broadcast_receiver: broadcast::Receiver<VerificationEvent>,
+    historic_sampling_broadcast_receiver: broadcast::Receiver<HistoricSamplingEvent>,
     _membership: PhantomData<Membership>,
 }
 
@@ -161,6 +165,9 @@ where
         let (verifying_broadcast_sender, verifying_broadcast_receiver) =
             broadcast::channel(BROADCAST_CHANNEL_SIZE);
 
+        let (historic_sampling_broadcast_sender, historic_sampling_broadcast_receiver) =
+            broadcast::channel(BROADCAST_CHANNEL_SIZE);
+
         let (replies_task_abort_handle, replies_task_abort_registration) = AbortHandle::new_pair();
         overwatch_handle.runtime().spawn(Abortable::new(
             handle_validator_events_stream(
@@ -168,6 +175,7 @@ where
                 sampling_broadcast_sender,
                 commitments_broadcast_sender,
                 verifying_broadcast_sender,
+                historic_sampling_broadcast_sender,
             ),
             replies_task_abort_registration,
         ));
@@ -183,6 +191,7 @@ where
             sampling_broadcast_receiver,
             commitments_broadcast_receiver,
             verifying_broadcast_receiver,
+            historic_sampling_broadcast_receiver,
             _membership: PhantomData,
         }
     }
@@ -245,6 +254,11 @@ where
                 BroadcastStream::new(self.verifying_broadcast_receiver.resubscribe())
                     .filter_map(|event| async { event.ok() })
                     .map(Self::NetworkEvent::Verifying),
+            ),
+            DaNetworkEventKind::HistoricSampling => Box::pin(
+                BroadcastStream::new(self.historic_sampling_broadcast_receiver.resubscribe())
+                    .filter_map(|event| async { event.ok() })
+                    .map(Self::NetworkEvent::HistoricSampling),
             ),
         }
     }


### PR DESCRIPTION
## 1. What does this PR implement?

In order to implement historical sampling in sampling service, there was a need to unify the types. 
Also request behavior types were updated to include blob id as it is needed to match light shares and commitments.
After this message in sampling service will be added and logic to sample and verify blobs, and return response to the caller.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?

No
## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
