### PR TITLE
chore(ci): cargo dany ignore tracing subscriber vulnerability

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -12,6 +12,7 @@ ignore = [
   { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is unmaintained; consider using an alternative. Use `cargo tree -p proc-macro-error -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained; consider using an alternative. Use `cargo tree -p derivative -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2024-0436", reason = "`paste` has a security vulnerability; consider using an alternative. Use `cargo tree -p paste -i > tmp.txt` to check the dependency tree." },
+  { id = "RUSTSEC-2025-0055", reason = "`tracing-subscriber` v0.2.25 pulled in by ark-relations v0.4.0 - will be addressed before mainnet" },
 ]
 yanked = "deny"
 


### PR DESCRIPTION
## 1. What does this PR implement?

This PR should fix the CI cargo-deny error. We will ignore tracing-subscriber vulnerability for now
