### PR TITLE
chore(zk): Re-export poseidon hash types in core

### DIFF
--- a/nomos-core/chain-defs/src/crypto.rs
+++ b/nomos-core/chain-defs/src/crypto.rs
@@ -2,4 +2,4 @@ use blake2::digest::typenum::U32;
 pub type Hasher = blake2::Blake2b<U32>;
 pub use blake2::digest::Digest;
 pub type ZkHasher = poseidon2::Poseidon2Bn254Hasher;
-pub use poseidon2::Digest as ZkDigest;
+pub use poseidon2::{Digest as ZkDigest, ZkHash};

--- a/nomos-core/chain-defs/src/crypto.rs
+++ b/nomos-core/chain-defs/src/crypto.rs
@@ -1,5 +1,7 @@
 use blake2::digest::typenum::U32;
 pub type Hasher = blake2::Blake2b<U32>;
 pub use blake2::digest::Digest;
+pub type Hash = [u8; 32];
+
 pub type ZkHasher = poseidon2::Poseidon2Bn254Hasher;
 pub use poseidon2::{Digest as ZkDigest, ZkHash};

--- a/nomos-core/chain-defs/src/mantle/tx.rs
+++ b/nomos-core/chain-defs/src/mantle/tx.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use bytes::Bytes;
 use groth16::{serde::serde_fr, Fr};
 use num_bigint::BigUint;
-use poseidon2::Digest;
+use poseidon2::{Digest, ZkHash};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -22,10 +22,10 @@ use crate::{
     Debug, Clone, Copy, PartialEq, Eq, Default, Hash, PartialOrd, Ord, Serialize, Deserialize,
 )]
 #[serde(transparent)]
-pub struct TxHash(#[serde(with = "serde_fr")] pub Fr);
+pub struct TxHash(#[serde(with = "serde_fr")] pub ZkHash);
 
-impl From<Fr> for TxHash {
-    fn from(fr: Fr) -> Self {
+impl From<ZkHash> for TxHash {
+    fn from(fr: ZkHash) -> Self {
         Self(fr)
     }
 }
@@ -36,14 +36,14 @@ impl From<BigUint> for TxHash {
     }
 }
 
-impl From<TxHash> for Fr {
+impl From<TxHash> for ZkHash {
     fn from(hash: TxHash) -> Self {
         hash.0
     }
 }
 
-impl AsRef<Fr> for TxHash {
-    fn as_ref(&self) -> &Fr {
+impl AsRef<ZkHash> for TxHash {
+    fn as_ref(&self) -> &ZkHash {
         &self.0
     }
 }

--- a/zk/poseidon2/src/lib.rs
+++ b/zk/poseidon2/src/lib.rs
@@ -4,11 +4,12 @@ use jf_poseidon2::Poseidon2;
 
 pub type Poseidon2Bn254 = Poseidon2<Fr>;
 pub type Poseidon2Bn254Hasher = hasher::Poseidon2Hasher;
+pub type ZkHash = Fr;
 
 pub trait Digest {
-    fn digest(inputs: &[Fr]) -> Fr;
+    fn digest(inputs: &[Fr]) -> ZkHash;
 
     fn new() -> Self;
     fn update(&mut self, input: &Fr);
-    fn finalize(self) -> Fr;
+    fn finalize(self) -> ZkHash;
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Exports some types for convinience in the poseidon2 crate. Re-export them in the core/crypto module too.
A tiny refactor of types comes with this changes too.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
