### PR TITLE
chore(membership): add waits to membership update tests

### DIFF
--- a/tests/src/tests/membership/api.rs
+++ b/tests/src/tests/membership/api.rs
@@ -75,6 +75,9 @@ async fn send_provider_update(
         })
         .await
         .unwrap();
+
+    // Wait for update to propagate
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 }
 
 async fn verify_session_zero_membership(executor: &Executor) {


### PR DESCRIPTION
## 1. What does this PR implement?
Simple PR that adds wait to try to stabilize update membership integration tests.