### PR TITLE
feat(membership): sessions per service type

### DIFF
--- a/nodes/nomos-executor/config.yaml
+++ b/nodes/nomos-executor/config.yaml
@@ -343,7 +343,8 @@ mempool:
     nanos: 0
 membership:
   backend:
-    session_size_blocks: 4320
-    session_zero_membership: {}
-    session_zero_locators_mapping: {}
+    session_sizes:
+      0: 4320  # DataAvailability - 4320 blocks per session
+    session_zero_memberships: {}
+    session_zero_locators: {}
 sdp:

--- a/nodes/nomos-node/config.yaml
+++ b/nodes/nomos-node/config.yaml
@@ -334,7 +334,8 @@ mempool:
     nanos: 0
 membership:
   backend:
-    session_size_blocks: 4320
-    session_zero_membership: {}
-    session_zero_locators_mapping: {}
+    session_sizes:
+      0: 4320  # DataAvailability - 4320 blocks per session
+    session_zero_memberships: {}
+    session_zero_locators: {}
 sdp:

--- a/nodes/nomos-node/node/src/api/backend.rs
+++ b/nodes/nomos-node/node/src/api/backend.rs
@@ -348,7 +348,7 @@ where
     type Error = hyper::Error;
     type Settings = AxumBackendSettings;
 
-    async fn new(settings: Self::Settings) -> Result<Self, Self::Error>
+    async fn new    (settings: Self::Settings) -> Result<Self, Self::Error>
     where
         Self: Sized,
     {

--- a/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
+++ b/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
@@ -191,7 +191,7 @@ where
 {
     type Settings = DispersalKZGRSBackendSettings;
     type Encoder = encoder::DaEncoder;
-    type Dispersal = DispersalHandler<NetworkAdapter, WalletAdapter>;
+    type Dispersal = DispersalHandler<NetworkAdapter, WalletAdapter>;   
     type NetworkAdapter = NetworkAdapter;
     type WalletAdapter = WalletAdapter;
     type BlobId = BlobId;

--- a/testnet/cfgsync/src/config.rs
+++ b/testnet/cfgsync/src/config.rs
@@ -260,9 +260,9 @@ pub fn create_membership_configs(ids: &[[u8; 32]], hosts: &[Host]) -> Vec<Genera
     }
 
     let mock_backend_settings = MockMembershipBackendSettings {
-        session_size_blocks: 1,
-        session_zero_membership: membership_entry,
-        session_zero_locators_mapping: initial_locators_mapping,
+        session_sizes: HashMap::from([(ServiceType::DataAvailability, 4)]),
+        session_zero_memberships: membership_entry,
+        session_zero_locators: initial_locators_mapping,
     };
 
     let config = GeneralMembershipConfig {

--- a/tests/src/tests/da/api.rs
+++ b/tests/src/tests/da/api.rs
@@ -104,7 +104,7 @@ async fn test_block_peer() {
         .config()
         .membership
         .backend
-        .session_zero_membership
+        .session_zero_memberships
         .get(&nomos_core::sdp::ServiceType::DataAvailability)
         .expect("Expected data availability membership");
     assert!(!membership.is_empty());

--- a/tests/src/tests/membership/api.rs
+++ b/tests/src/tests/membership/api.rs
@@ -43,7 +43,7 @@ fn get_initial_provider_id(executor: &Executor) -> &ProviderId {
         .config()
         .membership
         .backend
-        .session_zero_membership
+        .session_zero_memberships
         .get(&nomos_core::sdp::ServiceType::DataAvailability)
         .expect("Expected data availability membership")
         .iter()

--- a/tests/src/tests/membership/disperse.rs
+++ b/tests/src/tests/membership/disperse.rs
@@ -57,7 +57,7 @@ fn create_finalized_block_event(
     let non_zero_membership = membership_config
         .service_settings
         .backend
-        .session_zero_membership
+        .session_zero_memberships
         .get(&nomos_core::sdp::ServiceType::DataAvailability)
         .expect("Expected data availability membership");
 
@@ -80,7 +80,7 @@ fn create_block_event_updates(
             let locators = membership_config
                 .service_settings
                 .backend
-                .session_zero_locators_mapping
+                .session_zero_locators
                 .get(&nomos_core::sdp::ServiceType::DataAvailability)
                 .expect("Expected data availability service type")
                 .get(provider)

--- a/tests/src/topology/configs/membership.rs
+++ b/tests/src/topology/configs/membership.rs
@@ -58,9 +58,9 @@ pub fn create_membership_configs(ids: &[[u8; 32]], ports: &[u16]) -> Vec<General
     }
 
     let mock_backend_settings = MockMembershipBackendSettings {
-        session_size_blocks: 4,
-        session_zero_membership: initial_membership,
-        session_zero_locators_mapping: initial_locators_mapping,
+        session_sizes: HashMap::from([(ServiceType::DataAvailability, 4)]),
+        session_zero_memberships: initial_membership,
+        session_zero_locators: initial_locators_mapping,
     };
 
     let config = GeneralMembershipConfig {
@@ -80,9 +80,9 @@ pub fn create_empty_membership_configs(n_participants: usize) -> Vec<GeneralMemb
         membership_configs.push(GeneralMembershipConfig {
             service_settings: MembershipServiceSettings {
                 backend: MockMembershipBackendSettings {
-                    session_size_blocks: 4,
-                    session_zero_membership: HashMap::new(),
-                    session_zero_locators_mapping: HashMap::new(),
+                    session_sizes: HashMap::from([(ServiceType::DataAvailability, 4)]),
+                    session_zero_memberships: HashMap::new(),
+                    session_zero_locators: HashMap::new(),
                 },
             },
         });


### PR DESCRIPTION
## 1. What does this PR implement?

This PR implements support for different session intervals per service type, as data availability and blend don't have the same session sizes in blocks.

## 2. Does the code have enough context to be clearly understood?

Yes
## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 
## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
