### PR TITLE
fix(tests): Disable slow proptest in MMR

### DIFF
--- a/mmr/src/lib.rs
+++ b/mmr/src/lib.rs
@@ -235,6 +235,7 @@ mod test {
         assert_eq!(mmr.frontier_root(), root(&padded_leaves(elems, 8)));
     }
 
+    #[ignore = "very slow"]
     #[property_test]
     fn test_frontier_root_16(elems: Vec<[u8; 32]>) {
         let mut mmr = <MerkleMountainRange<TestFr, ZkHasher, 16>>::new();


### PR DESCRIPTION
## 1. What does this PR implement?
Disable a slow proptest, doing few iterations does not make sense for proptest
## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
N/A

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A
## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
