### PR TITLE
fix: membership test need to generate eliptic curve for pid

### DIFF
--- a/nomos-services/membership/Cargo.toml
+++ b/nomos-services/membership/Cargo.toml
@@ -21,4 +21,5 @@ tokio-stream   = { default-features = false, version = "0.1" }
 tracing        = { workspace = true }
 
 [dev-dependencies]
-multiaddr = { default-features = false, version = "0.18" }
+ed25519-dalek = { default-features = false, version = "2.0.0" }
+multiaddr     = { default-features = false, version = "0.18" }

--- a/nomos-services/membership/src/backends/mock.rs
+++ b/nomos-services/membership/src/backends/mock.rs
@@ -172,9 +172,14 @@ mod tests {
     use super::{MembershipBackend as _, MockMembershipBackend, MockMembershipBackendSettings};
 
     fn pid(seed: u8) -> ProviderId {
-        let mut b = [1u8; 32];
-        b[0] = seed;
-        ProviderId::try_from(b).unwrap()
+        use ed25519_dalek::SigningKey;
+
+        // Create a deterministic signing key from seed
+        let secret_bytes = [seed; 32];
+        let signing_key = SigningKey::from_bytes(&secret_bytes);
+        let verifying_key = signing_key.verifying_key();
+
+        ProviderId(verifying_key)
     }
 
     fn locator(seed: u8) -> Locator {


### PR DESCRIPTION
## 1. What does this PR implement?

This fixes a membership tests that creates mock provider ids