### PR TITLE
Update epoch nonce to use poseidon2

### DIFF
--- a/ledger/nomos-ledger/Cargo.toml
+++ b/ledger/nomos-ledger/Cargo.toml
@@ -26,4 +26,4 @@ ed25519-dalek = { default-features = false, version = "2.0.0" }
 rand          = { features = ["std", "std_rng"], workspace = true }
 
 [features]
-serde = ["cryptarchia-engine/serde", "dep:nomos-utils", "dep:serde", "utxotree/serde"]
+serde = ["cryptarchia-engine/serde", "dep:nomos-utils", "dep:serde", "groth16/deser", "utxotree/serde"]

--- a/nomos-services/chain/chain-service/src/leadership.rs
+++ b/nomos-services/chain/chain-service/src/leadership.rs
@@ -1,5 +1,5 @@
 use cryptarchia_engine::Slot;
-use groth16::{fr_from_bytes, Fr};
+use groth16::Fr;
 use nomos_core::{
     mantle::{keys::SecretKey, ops::leader_claim::VoucherCm, Utxo},
     proofs::leader_proof::{Groth16LeaderProof, LeaderPrivate, LeaderPublic},
@@ -51,13 +51,10 @@ impl Leader {
             };
 
             let note_id: Fr = BigUint::from(1u8).into(); // placeholder for note ID, replace after mantle notes format update
-                                                         // TODO: horrible hack to convert epoch nonce to Fr, use native Fr epoch nonce
-            let epoch_nonce_fr =
-                fr_from_bytes(&epoch_state.nonce()[..31]).expect("epoch nonce fits in Fr");
             let public_inputs = LeaderPublic::new(
                 aged_tree.root(),
                 latest_tree.root(),
-                epoch_nonce_fr,
+                epoch_state.nonce,
                 slot.into(),
                 epoch_state.total_stake(),
             );


### PR DESCRIPTION
## 1. What does this PR implement?
Update the epoch nonce after the recent changes to switch to poseidon2

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
[spec](https://www.notion.so/nomos-tech/Cryptarchia-v1-Protocol-Specification-21c261aa09df810cb85eff1c76e5798c), @davidrusu , @zeegomo implementing

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
