### PR TITLE
Fix da network historic addressbook

### DIFF
--- a/nomos-services/data-availability/network/src/storage/mod.rs
+++ b/nomos-services/data-availability/network/src/storage/mod.rs
@@ -106,6 +106,10 @@ where
         self.membership_adapter.store_addresses(new_members).await
     }
 
+    pub fn update_addressbook(&self, new_members: AddressBookSnapshot<Membership::Id>) {
+        self.addressbook.update(new_members);
+    }
+
     pub async fn get_historic_membership(
         &self,
         session_id: SessionNumber,

--- a/nomos-services/data-availability/network/src/storage/mod.rs
+++ b/nomos-services/data-availability/network/src/storage/mod.rs
@@ -127,4 +127,8 @@ where
 
         Ok(Some(membership.unwrap()))
     }
+
+    pub async fn get_address(&self, id: Membership::Id) -> Result<Option<Multiaddr>, DynError> {
+        self.membership_adapter.get_address(id).await
+    }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

The historic sampling is using the same address book as regular sampling. This address book is growing and holds both historic and new addresses. However, the historic addresses were not loaded, so some peers might be missing. 

The other way would be to provide a address book snapshot to historic sampling behavior, but the problem there is that it needs address book in main poll fn in order to handle stream dials and extend behavior addresses.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 
## 4. Is the specification accurate and complete?

>Yes
## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
