### PR TITLE
feat(da): return assignations instead of panic when nodes < replication factor

### DIFF
--- a/nomos-da/network/subnetworks-assignations/src/versions/history_aware_refill/assignations.rs
+++ b/nomos-da/network/subnetworks-assignations/src/versions/history_aware_refill/assignations.rs
@@ -552,4 +552,30 @@ mod tests {
         .collect();
         assert!(assignations.iter().all(|a| a == &assignations[0]));
     }
+
+    #[test]
+    fn test_insufficient_nodes() {
+        let mut rng = thread_rng();
+
+        let nodes: Vec<TestId> = std::iter::repeat_with(|| {
+            let mut buff = [0u8; 32];
+            rng.fill_bytes(&mut buff);
+            TestId(buff)
+        })
+        .take(3)
+        .collect();
+
+        let previous_nodes: Vec<BTreeSet<TestId>> = std::iter::repeat_with(BTreeSet::new)
+            .take(SUBNETWORK_SIZE)
+            .collect();
+
+        let assignations = HistoryAwareRefill::calculate_subnetwork_assignations(
+            &nodes,
+            previous_nodes,
+            REPLICATION_FACTOR,
+            &mut rng,
+        );
+
+        assert!(assignations.is_empty());
+    }
 }

--- a/nomos-da/network/subnetworks-assignations/src/versions/history_aware_refill/assignations.rs
+++ b/nomos-da/network/subnetworks-assignations/src/versions/history_aware_refill/assignations.rs
@@ -204,10 +204,11 @@ impl HistoryAwareRefill {
         for<'id> Id: Ord + Copy + Hash + 'id,
         Rng: RngCore,
     {
-        assert!(
-            new_nodes_list.len() >= replication_factor,
-            "The network size is smaller than the replication factor"
-        );
+        // Behaviors can skip when assignations are empty
+        if new_nodes_list.len() < replication_factor {
+            return Vec::new();
+        }
+
         // The algorithm works as follows:
         // 1. Remove nodes that are not active from the previous subnetworks
         //    assignations


### PR DESCRIPTION
## 1. What does this PR implement?
Return empty assignations when the number of nodes is less then replication factor. The code used to panic in this case. This is handling it more gracefully, so the behaviors can skip the work in this case.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic @danielSanchezQ 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
