### PR TITLE
feat(chain): mark the service as ready after bootstrapping is done

### DIFF
--- a/nomos-services/chain/chain-leader/src/lib.rs
+++ b/nomos-services/chain/chain-leader/src/lib.rs
@@ -322,9 +322,6 @@ where
             loop {
                 tokio::select! {
                     Some(SlotTick { slot, .. }) = slot_timer.next() => {
-                        // TODO: Don't propose blocks until IBD is done and online mode is activated.
-                        //       Until then, mempool, DA, blend service will not be ready: https://github.com/logos-co/nomos/issues/1656
-
                         let chain_info = match cryptarchia_api.info().await {
                             Ok(info) => info,
                             Err(e) => {

--- a/nomos-services/chain/chain-service/src/lib.rs
+++ b/nomos-services/chain/chain-service/src/lib.rs
@@ -542,12 +542,6 @@ where
             sync_config.orphan.max_orphan_cache_size,
         ));
 
-        self.service_resources_handle.status_updater.notify_ready();
-        info!(
-            "Service '{}' is ready.",
-            <RuntimeServiceId as AsServiceId<Self>>::SERVICE_ID
-        );
-
         wait_until_services_are_ready!(
             &self.service_resources_handle.overwatch_handle,
             Some(Duration::from_secs(60)),
@@ -644,6 +638,12 @@ where
                 Box::new(RecentBlobValidation::new(relays.sampling_relay().clone()))
             };
 
+        // Mark the service as ready if the chain is in the Online state.
+        // If not, it will be marked as ready after Prolonged Bootstrap Period ends.
+        if cryptarchia.state().is_online() {
+            self.notify_service_ready();
+        }
+
         let async_loop = async {
             loop {
                 tokio::select! {
@@ -660,6 +660,8 @@ where
                             storage_blocks_to_remove.clone(),
                             &self.service_resources_handle.state_updater,
                         );
+
+                        self.notify_service_ready();
                     }
 
                     Some(block) = incoming_blocks.next() => {
@@ -860,7 +862,16 @@ where
     SamplingStorage: nomos_da_sampling::storage::DaStorageAdapter<RuntimeServiceId>,
     TimeBackend: nomos_time::backends::TimeBackend,
     TimeBackend::Settings: Clone + Send + Sync,
+    RuntimeServiceId: Display + AsServiceId<Self>,
 {
+    fn notify_service_ready(&self) {
+        self.service_resources_handle.status_updater.notify_ready();
+        info!(
+            "Service '{}' is ready.",
+            <RuntimeServiceId as AsServiceId<Self>>::SERVICE_ID
+        );
+    }
+
     fn process_message(
         cryptarchia: &Cryptarchia,
         new_block_channel: &broadcast::Sender<HeaderId>,

--- a/nomos-services/wallet/Cargo.toml
+++ b/nomos-services/wallet/Cargo.toml
@@ -6,16 +6,25 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = "0.1"
+futures     = { default-features = false, version = "0.3" }
 serde       = { version = "1.0", features = ["derive"] }
 thiserror   = "1.0"
 tokio       = { version = "1", features = ["sync"] }
 tracing     = { workspace = true }
 
-chain-service = { workspace = true }
-nomos-core    = { workspace = true }
-nomos-storage = { workspace = true, features = ["mock"] }
-overwatch     = { workspace = true }
-wallet        = { workspace = true }
+chain-service      = { workspace = true }
+nomos-core         = { workspace = true }
+nomos-storage      = { workspace = true, features = ["mock"] }
+overwatch          = { workspace = true }
+services-utils     = { workspace = true }
+wallet             = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-machete]
+# False positives.
+ignored = [
+  # Required by `wait_until_services_are_ready` macro.
+  "futures",
+]

--- a/nomos-services/wallet/Cargo.toml
+++ b/nomos-services/wallet/Cargo.toml
@@ -7,17 +7,17 @@ version = "0.1.0"
 [dependencies]
 async-trait = "0.1"
 futures     = { default-features = false, version = "0.3" }
-serde       = { version = "1.0", features = ["derive"] }
+serde       = { features = ["derive"], version = "1.0" }
 thiserror   = "1.0"
-tokio       = { version = "1", features = ["sync"] }
+tokio       = { features = ["sync"], version = "1" }
 tracing     = { workspace = true }
 
-chain-service      = { workspace = true }
-nomos-core         = { workspace = true }
-nomos-storage      = { workspace = true, features = ["mock"] }
-overwatch          = { workspace = true }
-services-utils     = { workspace = true }
-wallet             = { workspace = true }
+chain-service  = { workspace = true }
+nomos-core     = { workspace = true }
+nomos-storage  = { features = ["mock"], workspace = true }
+overwatch      = { workspace = true }
+services-utils = { workspace = true }
+wallet         = { workspace = true }
 
 [lints]
 workspace = true

--- a/nomos-services/wallet/src/lib.rs
+++ b/nomos-services/wallet/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
 use async_trait::async_trait;
 use chain_service::{
@@ -20,6 +20,7 @@ use overwatch::{
     },
 };
 use serde::{Serialize, de::DeserializeOwned};
+use services_utils::wait_until_services_are_ready;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, trace};
 use wallet::{Wallet, WalletBlock, WalletError};
@@ -115,6 +116,14 @@ where
             mut service_resources_handle,
             ..
         } = self;
+
+        wait_until_services_are_ready!(
+            &service_resources_handle.overwatch_handle,
+            Some(Duration::from_secs(60)),
+            nomos_storage::StorageService<_, _>,
+            Cryptarchia
+        )
+        .await?;
 
         let settings = service_resources_handle
             .settings_handle

--- a/testnet/cfgsync/src/config.rs
+++ b/testnet/cfgsync/src/config.rs
@@ -2,7 +2,6 @@ use std::{
     collections::{BTreeSet, HashMap},
     net::Ipv4Addr,
     str::FromStr as _,
-    time::Duration,
 };
 
 use nomos_core::sdp::{Locator, ServiceType};
@@ -19,7 +18,7 @@ use tests::{
         GeneralConfig,
         api::GeneralApiConfig,
         blend::create_blend_configs,
-        bootstrap::create_bootstrap_configs,
+        bootstrap::{SHORT_PROLONGED_BOOTSTRAP_PERIOD, create_bootstrap_configs},
         consensus::{ConsensusParams, create_consensus_configs},
         da::{DaParams, create_da_configs},
         membership::GeneralMembershipConfig,
@@ -91,7 +90,7 @@ pub fn create_node_configs(
     }
 
     let consensus_configs = create_consensus_configs(&ids, consensus_params);
-    let bootstrap_configs = create_bootstrap_configs(&ids, Duration::from_secs(60));
+    let bootstrap_configs = create_bootstrap_configs(&ids, SHORT_PROLONGED_BOOTSTRAP_PERIOD);
     let da_configs = create_da_configs(&ids, da_params, &ports);
     let network_configs = create_network_configs(&ids, &NetworkParams::default());
     let membership_configs = create_membership_configs(&ids, &hosts);

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -90,9 +90,7 @@ pub struct Validator {
 
 impl Drop for Validator {
     fn drop(&mut self) {
-        if std::thread::panicking()
-            && let Err(e) = persist_tempdir(&mut self.tempdir, "nomos-node")
-        {
+        if let Err(e) = persist_tempdir(&mut self.tempdir, "nomos-node") {
             println!("failed to persist tempdir: {e}");
         }
 

--- a/tests/src/topology/configs/bootstrap.rs
+++ b/tests/src/topology/configs/bootstrap.rs
@@ -5,6 +5,8 @@ pub struct GeneralBootstrapConfig {
     pub prolonged_bootstrap_period: Duration,
 }
 
+pub const SHORT_PROLONGED_BOOTSTRAP_PERIOD: Duration = Duration::from_secs(1);
+
 #[must_use]
 pub fn create_bootstrap_configs(
     ids: &[[u8; 32]],

--- a/tests/src/topology/configs/mod.rs
+++ b/tests/src/topology/configs/mod.rs
@@ -10,7 +10,7 @@ pub mod tracing;
 
 pub mod time;
 
-use std::{iter::repeat, time::Duration};
+use std::iter::repeat;
 
 use blend::GeneralBlendConfig;
 use consensus::GeneralConsensusConfig;
@@ -22,7 +22,7 @@ use tracing::GeneralTracingConfig;
 
 use crate::topology::configs::{
     api::GeneralApiConfig,
-    bootstrap::GeneralBootstrapConfig,
+    bootstrap::{GeneralBootstrapConfig, SHORT_PROLONGED_BOOTSTRAP_PERIOD},
     consensus::ConsensusParams,
     da::DaParams,
     membership::{GeneralMembershipConfig, MembershipNode},
@@ -79,7 +79,8 @@ pub fn create_general_configs_with_blend_core_subset(
 
     let consensus_params = ConsensusParams::default_for_participants(n_nodes);
     let consensus_configs = consensus::create_consensus_configs(&ids, &consensus_params);
-    let bootstrap_config = bootstrap::create_bootstrap_configs(&ids, Duration::from_secs(20));
+    let bootstrap_config =
+        bootstrap::create_bootstrap_configs(&ids, SHORT_PROLONGED_BOOTSTRAP_PERIOD);
     let network_configs = network::create_network_configs(&ids, network_params);
     let da_configs = da::create_da_configs(&ids, &DaParams::default(), &da_ports);
     let api_configs = api::create_api_configs(&ids);

--- a/tests/src/topology/mod.rs
+++ b/tests/src/topology/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     topology::configs::{
         api::create_api_configs,
         blend::create_blend_configs,
-        bootstrap::create_bootstrap_configs,
+        bootstrap::{SHORT_PROLONGED_BOOTSTRAP_PERIOD, create_bootstrap_configs},
         consensus::{ConsensusParams, create_consensus_configs},
         membership::{MembershipNode, create_membership_configs},
         time::default_time_config,
@@ -126,7 +126,7 @@ impl Topology {
         }
 
         let consensus_configs = create_consensus_configs(&ids, &config.consensus_params);
-        let bootstrapping_config = create_bootstrap_configs(&ids, Duration::from_secs(30));
+        let bootstrapping_config = create_bootstrap_configs(&ids, SHORT_PROLONGED_BOOTSTRAP_PERIOD);
         let da_configs = create_da_configs(&ids, &config.da_params, &da_ports);
         let membership_configs = create_membership_configs(
             ids.iter()
@@ -181,7 +181,7 @@ impl Topology {
         let n_participants = config.n_validators + config.n_executors;
 
         let consensus_configs = create_consensus_configs(ids, &config.consensus_params);
-        let bootstrapping_config = create_bootstrap_configs(ids, Duration::from_secs(60));
+        let bootstrapping_config = create_bootstrap_configs(ids, SHORT_PROLONGED_BOOTSTRAP_PERIOD);
         let da_configs = create_da_configs(ids, &config.da_params, da_ports);
         let network_configs = create_network_configs(ids, &config.network_params);
         let blend_configs = create_blend_configs(ids, blend_ports);


### PR DESCRIPTION
## 1. What does this PR implement?

Closes #1656 

This PR makes the chain service mark itself as ready only after it has fully completed bootstrapping (**IBD + ProlongedBootstrapPeriod**).
In other words, the chain service becomes ready only after **IBD** is done and Cryptarchia switches to **Online**. 

We made this decision so that other services become operational only after the **LIB** is available.

There are currently 3 services that explicitly wait until the chain service becomes ready.
- chain-leader
- wallet
  - It wasn't calling `wait_until_services_are_ready`. This PR adds it.
- api
  - But we may want this service to begin its job earlier even before the chain is ready. I didn’t do it in this PR, as it's not urgent and requires other fixes alongside. If we need it, we can do it nicely by the refactoring that I mentioned below.

In a next PR, I will refactor the chain service into two types (Bootstrapping and Online) to clearly separate their behavior. I didn't do the refactoring in this PR to show the diffs clearly.


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@zeegomo @youngjoon-lee 

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
