### PR TITLE
chore(codeowners): Add third codeowner to avoid pr locking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,13 +6,13 @@
 /ledger/ @zeegomo @danielSanchezQ @davidrusu @bacv
 
 # Blend
-/nomos-blend/  @youngjoon-lee @ntn-x2
-/nomos-services/blend @youngjoon-lee @ntn-x2
+/nomos-blend/  @youngjoon-lee @ntn-x2 @danielSanchezQ
+/nomos-services/blend @youngjoon-lee @ntn-x2 @danielSanchezQ
 
 # DA
 /nomos-services/data-availability @danielSanchezQ @bacv @pradovic
 /nomos-da/ @danielSanchezQ @bacv @pradovic
 
 # SDP
-/nomos-sdp/ @bacv @pradovic
-/nomos-services/sdp @bacv @pradovic
+/nomos-sdp/ @bacv @pradovic @danielSanchezQ
+/nomos-services/sdp @bacv @pradovic @danielSanchezQ


### PR DESCRIPTION
## 1. What does this PR implement?

Added myself as codeowner in the folders that may locke PRs.

## 2. Does the code have enough context to be clearly understood?
N/A

## 3. Who are the specification authors and who is accountable for this PR?
N/A

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
